### PR TITLE
Use config for API URLs

### DIFF
--- a/src/autopilot.js
+++ b/src/autopilot.js
@@ -1,3 +1,5 @@
+import { CONTROL_API_URL } from './config.js';
+
 export async function followPath(car, pathCells, cellSize) {
   if (!car || !Array.isArray(pathCells) || pathCells.length < 2) return;
   if (followPath.running) return;
@@ -7,7 +9,7 @@ export async function followPath(car, pathCells, cellSize) {
   const send = async action => {
     car.setKeysFromAction(action);
     try {
-      await fetch('http://localhost:5002/api/control', {
+      await fetch(CONTROL_API_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action })

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,2 @@
+export const CONTROL_API_URL = 'http://localhost:5002/api/control';
+export const TELEMETRY_API_URL = 'http://127.0.0.1:5001/api/car';

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { Target } from './Target.js';
 import { generateMaze, generateBorder } from './mapGenerator.js';
 import * as db from './db.js';
 import { followPath, aStar } from './autopilot.js';
+import { CONTROL_API_URL, TELEMETRY_API_URL } from './config.js';
 
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
@@ -30,7 +31,7 @@ const CONTROL_POLL_INTERVAL = 200; // ms
 
 async function pollControl() {
   try {
-    const res = await fetch('http://localhost:5002/api/control');
+    const res = await fetch(CONTROL_API_URL);
     if (!res.ok) return;
     const data = await res.json();
     if (data.action) car.setKeysFromAction(data.action);
@@ -40,7 +41,7 @@ async function pollControl() {
 }
 
 function sendTelemetry(front, rear, left, right) {
-  fetch('http://127.0.0.1:5001/api/car', {
+  fetch(TELEMETRY_API_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- centralize API endpoint URLs in `config.js`
- consume config URLs from `main.js` and `autopilot.js`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687281907aa48331a428c913ad87534a