### PR TITLE
Fix obstacle collision detection

### DIFF
--- a/map2.html
+++ b/map2.html
@@ -91,6 +91,7 @@
     <button id="saveMap">Download Map</button>
     <button id="loadMapBtn">Load Map</button>
     <button id="calcPathBtn">Optimal Pathfinder</button>
+    <button id="toggleHitboxes">Hitboxen anzeigen</button>
     <input type="file" id="loadMap" style="display:none" accept="application/json">
   </div>
   <canvas id="canvas"></canvas>

--- a/src/Obstacle.js
+++ b/src/Obstacle.js
@@ -15,6 +15,12 @@ export class Obstacle {
     ctx.fillRect(this.x, this.y, this.size, this.size);
   }
 
+  drawHitbox(ctx) {
+    ctx.strokeStyle = 'red';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(this.x, this.y, this.size, this.size);
+  }
+
   intersectsRect(x, y, w, h) {
     return !(
       x + w < this.x ||

--- a/src/car.js
+++ b/src/car.js
@@ -13,6 +13,8 @@ export class Car {
     this.margin = margin;
     this.objects = objects;
 
+    this.showHitbox = false;
+
     this.imgWidth = 150 * scale;
     this.imgHeight = 80 * scale;
 
@@ -74,6 +76,51 @@ export class Car {
     this.ctx.fillRect(0, canvasHeight - m, canvasWidth, m);
     this.ctx.fillRect(0, 0, m, canvasHeight);
     this.ctx.fillRect(canvasWidth - m, 0, m, canvasHeight);
+  }
+
+  getRotatedCorners(x, y, rotation = this.rotation) {
+    const cx = x + this.imgWidth / 2;
+    const cy = y + this.imgHeight / 2;
+    const w = this.imgWidth;
+    const h = this.imgHeight;
+    const cos = Math.cos(rotation);
+    const sin = Math.sin(rotation);
+    return [
+      [x, y],
+      [x + w, y],
+      [x + w, y + h],
+      [x, y + h],
+    ].map(([px, py]) => {
+      const dx = px - cx;
+      const dy = py - cy;
+      const rx = dx * cos - dy * sin;
+      const ry = dx * sin + dy * cos;
+      return [cx + rx, cy + ry];
+    });
+  }
+
+  getBoundingBox(x, y, rotation = this.rotation) {
+    const corners = this.getRotatedCorners(x, y, rotation);
+    const xs = corners.map((c) => c[0]);
+    const ys = corners.map((c) => c[1]);
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    return {
+      x: minX,
+      y: minY,
+      w: Math.max(...xs) - minX,
+      h: Math.max(...ys) - minY,
+    };
+  }
+
+  drawHitbox() {
+    const corners = this.getRotatedCorners(this.posX, this.posY);
+    this.ctx.strokeStyle = 'red';
+    this.ctx.beginPath();
+    this.ctx.moveTo(corners[0][0], corners[0][1]);
+    for (const [x, y] of corners.slice(1)) this.ctx.lineTo(x, y);
+    this.ctx.closePath();
+    this.ctx.stroke();
   }
 
   drawKegel(x, y, length, angle, color, baseWidth) {
@@ -144,6 +191,8 @@ export class Car {
     this.ctx.translate(-this.imgWidth / 2, -this.imgHeight / 2);
     this.ctx.drawImage(this.bg, 0, 0, this.imgWidth, this.imgHeight);
     this.ctx.restore();
+
+    if (this.showHitbox) this.drawHitbox();
 
     for (const o of this.objects) {
       if (typeof o.draw === 'function') {
@@ -228,6 +277,8 @@ export class Car {
 
     const nx = this.posX + Math.cos(this.rotation) * this.velocity;
     const ny = this.posY + Math.sin(this.rotation) * this.velocity;
+    const newRotation = this.rotation + this.angularVelocity;
+    const bbox = this.getBoundingBox(nx, ny, newRotation);
 
     const inBounds =
       nx >= this.margin &&
@@ -237,12 +288,12 @@ export class Car {
 
     if (inBounds) {
       const hit = this.objects.some((obs) =>
-        obs.intersectsRect(nx, ny, this.imgWidth, this.imgHeight),
+        obs.intersectsRect(bbox.x, bbox.y, bbox.w, bbox.h),
       );
       if (!hit) {
         this.posX = nx;
         this.posY = ny;
-        this.rotation += this.angularVelocity;
+        this.rotation = newRotation;
       } else {
         this.velocity =
           this.acceleration =

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ const dropdown = document.getElementById('obstacleSize');
 const removeCheckbox = document.getElementById('removeMode');
 const generateMazeBtn = document.getElementById('generateMaze');
 const calcPathBtn = document.getElementById('calcPathBtn');
+const toggleHitboxesBtn = document.getElementById('toggleHitboxes');
 const redEl = document.getElementById('redLength');
 const greenEl = document.getElementById('greenLength');
 const blueLeft1El = document.getElementById('blueLeft1');
@@ -59,6 +60,7 @@ let gameMap = new GameMap(20, 15);
 let CELL_SIZE = gameMap.cellSize;
 let obstacles = gameMap.obstacles;
 let previewSize = parseInt(dropdown.value);
+let showHitboxes = false;
 let isDragging = false;
 let dragX = 0;
 let dragY = 0;
@@ -180,7 +182,10 @@ function drawGrid() {
 function loop() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   drawGrid();
-  for (const o of obstacles) o.draw(ctx);
+  for (const o of obstacles) {
+    o.draw(ctx);
+    if (showHitboxes && typeof o.drawHitbox === 'function') o.drawHitbox(ctx);
+  }
   if (targetMarker) {
     targetMarker.draw(ctx);
   }
@@ -201,6 +206,7 @@ function loop() {
     ctx.lineWidth = 2;
     ctx.strokeRect(dragX, dragY, previewSize, previewSize);
   }
+  car.showHitbox = showHitboxes;
   car.update(canvas.width, canvas.height);
   if (
     targetMarker &&
@@ -379,6 +385,14 @@ calcPathBtn.addEventListener('click', () => {
   goal.y = Math.min(goal.y, gameMap.rows - 2);
   pathCells = aStar(start, goal, gameMap);
   followPath(car, pathCells, CELL_SIZE);
+});
+
+toggleHitboxesBtn.addEventListener('click', () => {
+  showHitboxes = !showHitboxes;
+  car.showHitbox = showHitboxes;
+  toggleHitboxesBtn.textContent = showHitboxes
+    ? 'Hitboxen verstecken'
+    : 'Hitboxen anzeigen';
 });
 
 carImage.onload = () => {


### PR DESCRIPTION
## Summary
- add rotated bounding box calculation for the car
- block movement if the rotated bounding box intersects an obstacle
- highlight the car's hitbox in red for easier debugging
- add button to toggle hitboxes for car and obstacles

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68728a557f6c833193c7b48a0d3bb647