### PR TITLE
Organize autopilot module

### DIFF
--- a/src/autopilot/index.js
+++ b/src/autopilot/index.js
@@ -1,4 +1,4 @@
-import { CONTROL_API_URL } from './config.js';
+import { CONTROL_API_URL } from '../config.js';
 
 export async function followPath(car, pathCells, cellSize) {
   if (!car || !Array.isArray(pathCells) || pathCells.length < 2) return;

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { Obstacle } from './Obstacle.js';
 import { Target } from './Target.js';
 import { generateMaze, generateBorder } from './mapGenerator.js';
 import * as db from './db.js';
-import { followPath, aStar } from './autopilot.js';
+import { followPath, aStar } from './autopilot/index.js';
 import { CONTROL_API_URL, TELEMETRY_API_URL } from './config.js';
 
 const canvas = document.getElementById('canvas');


### PR DESCRIPTION
## Summary
- move `src/autopilot.js` into `src/autopilot/index.js`
- update imports to reference the new path

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6872a83c5fe48331b9fe0d4dc6b4a78e