### PR TITLE
Implement car hotbox

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -5,7 +5,12 @@ export class Car {
     scale,
     margin,
     objects,
-    { startX = 200, startY = 200 } = {},
+    {
+      startX = 200,
+      startY = 200,
+      hitboxWidth = null,
+      hitboxHeight = null,
+    } = {},
   ) {
     this.ctx = ctx;
     this.bg = image;
@@ -17,6 +22,11 @@ export class Car {
 
     this.imgWidth = 150 * scale;
     this.imgHeight = 80 * scale;
+
+    this.hitboxWidth =
+      hitboxWidth != null ? hitboxWidth : this.imgWidth;
+    this.hitboxHeight =
+      hitboxHeight != null ? hitboxHeight : this.imgHeight;
 
     this.posX = startX;
     this.posY = startY;
@@ -81,15 +91,17 @@ export class Car {
   getRotatedCorners(x, y, rotation = this.rotation) {
     const cx = x + this.imgWidth / 2;
     const cy = y + this.imgHeight / 2;
-    const w = this.imgWidth;
-    const h = this.imgHeight;
+    const w = this.hitboxWidth;
+    const h = this.hitboxHeight;
+    const offsetX = (this.imgWidth - w) / 2;
+    const offsetY = (this.imgHeight - h) / 2;
     const cos = Math.cos(rotation);
     const sin = Math.sin(rotation);
     const corners = [
-      [x, y],
-      [x + w, y],
-      [x + w, y + h],
-      [x, y + h],
+      [x + offsetX, y + offsetY],
+      [x + offsetX + w, y + offsetY],
+      [x + offsetX + w, y + offsetY + h],
+      [x + offsetX, y + offsetY + h],
     ].map(([px, py]) => {
       const dx = px - cx;
       const dy = py - cy;
@@ -282,10 +294,10 @@ export class Car {
     const bbox = this.getBoundingBox(nx, ny, newRotation);
 
     const inBounds =
-      nx >= this.margin &&
-      ny >= this.margin &&
-      nx + this.imgWidth <= canvasWidth - this.margin &&
-      ny + this.imgHeight <= canvasHeight - this.margin;
+      bbox.x >= this.margin &&
+      bbox.y >= this.margin &&
+      bbox.x + bbox.w <= canvasWidth - this.margin &&
+      bbox.y + bbox.h <= canvasHeight - this.margin;
 
     if (inBounds) {
       const hit = this.objects.some((obs) =>

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -114,9 +114,10 @@ function respawnTarget() {
     const y = row * CELL_SIZE;
     if (!gameMap.isWithinBounds(x, y, size, size)) continue;
     const temp = new Target(x, y, size);
+    const bbox = car.getBoundingBox(car.posX, car.posY);
     const collides =
       obstacles.some((o) => o.intersectsRect(x, y, size, size)) ||
-      temp.intersectsRect(car.posX, car.posY, car.imgWidth, car.imgHeight);
+      temp.intersectsRect(bbox.x, bbox.y, bbox.w, bbox.h);
     if (!collides) {
       targetMarker = temp;
       gameMap.target = targetMarker;
@@ -128,9 +129,13 @@ function respawnTarget() {
 
 const carImage = new Image();
 carImage.src = '/static/extracted_foreground.png';
+const HOTBOX_WIDTH_CM = 20;
+const HOTBOX_HEIGHT_CM = 40;
 const car = new Car(ctx, carImage, 0.5, 0, obstacles, {
   startX: 100,
   startY: 100,
+  hitboxWidth: HOTBOX_WIDTH_CM / CM_PER_PX,
+  hitboxHeight: HOTBOX_HEIGHT_CM / CM_PER_PX,
 });
 refreshCarObjects();
 
@@ -251,11 +256,18 @@ function loop() {
   }
   car.showHitbox = showHitboxes;
   car.update(canvas.width, canvas.height);
-  if (
-    targetMarker &&
-    targetMarker.intersectsRect(car.posX, car.posY, car.imgWidth, car.imgHeight)
-  ) {
-    respawnTarget();
+  if (targetMarker) {
+    const bboxCurrent = car.getBoundingBox(car.posX, car.posY);
+    if (
+      targetMarker.intersectsRect(
+        bboxCurrent.x,
+        bboxCurrent.y,
+        bboxCurrent.w,
+        bboxCurrent.h,
+      )
+    ) {
+      respawnTarget();
+    }
   }
 
   redEl.textContent = Math.round(car.redConeLength);


### PR DESCRIPTION
## Summary
- add `hitboxWidth` and `hitboxHeight` options to `Car` and base all
  collision calculations on this hotbox
- size car's hotbox to 20 cm × 40 cm in `main.js`
- use hotbox when checking collisions with the target

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687424c419d08331a6bc24da7147be5e