### PR TITLE
Add overwrite CSV feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ Without these servers the related features of the HTML page will not work.
 The control panel of `map2.html` contains buttons for working with maps. Maps
 can be saved and loaded locally as JSON or CSV files. The previous server based
 database for storing maps has been removed, so all map management now happens
-through file download and upload only.
+through file download and upload only. When editing a map that was loaded from
+the server's CSV list you can use the **CSV überschreiben** button to overwrite
+the original file instead of downloading a new one.

--- a/server.py
+++ b/server.py
@@ -70,6 +70,27 @@ def csv_maps():
         return jsonify(maps_list)
 
 
+@app.route('/api/csv-maps/<filename>', methods=['PUT'])
+def update_csv_map(filename):
+    secure_name = secure_filename(filename)
+    path = os.path.join(CSV_MAPS_FOLDER, secure_name)
+    if not os.path.exists(path):
+        return jsonify({'error': 'not found'}), 404
+    data = request.get_json(force=True)
+    csv_data = data.get('csv')
+    if not csv_data:
+        return jsonify({'error': 'missing csv'}), 400
+    with open(path, 'w') as f:
+        f.write(csv_data)
+    maps_list = load_csv_map_list()
+    for entry in maps_list:
+        if entry['file'] == secure_name:
+            entry['created'] = datetime.utcnow().isoformat()
+            break
+    save_csv_map_list(maps_list)
+    return '', 204
+
+
 @app.route('/api/maps', methods=['GET', 'POST'])
 def maps_route():
     if request.method == 'POST':

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -20,6 +20,7 @@ const toggleHitboxesBtn = document.getElementById('toggleHitboxes');
 const findCarBtn = document.getElementById('findCarBtn');
 const canvasContainer = document.getElementById('canvasContainer');
 const saveMapCsvBtn = document.getElementById('saveMapCsv');
+const overwriteCsvBtn = document.getElementById('overwriteMapCsv');
 const loadMapCsvInput = document.getElementById('loadMapCsv');
 const loadMapCsvBtn = document.getElementById('loadMapCsvBtn');
 const redEl = document.getElementById('redLength');
@@ -86,6 +87,7 @@ updateObstacleOptions();
 const params = new URLSearchParams(window.location.search);
 const csvMapUrl = params.get('map');
 const editorMode = params.has('editor');
+let currentCsvFile = null;
 if (!editorMode) {
   const e1 = document.getElementById('editorTools');
   const e2 = document.getElementById('editorTools2');
@@ -93,6 +95,11 @@ if (!editorMode) {
   if (e2) e2.style.display = 'none';
 }
 if (csvMapUrl) {
+  if (csvMapUrl.startsWith('/static/maps/')) {
+    currentCsvFile = decodeURIComponent(csvMapUrl.substring('/static/maps/'.length));
+    const nameInput = document.getElementById('mapName');
+    if (nameInput && !nameInput.value) nameInput.value = currentCsvFile;
+  }
   db.loadMapCsvUrl(csvMapUrl).then((gm) => {
     gameMap = gm;
     CELL_SIZE = gameMap.cellSize;
@@ -407,6 +414,21 @@ if (editorMode) {
     db.downloadMapCsv(gameMap, n + '.csv');
     db.uploadCsvMap(n, csv);
   });
+  if (currentCsvFile) {
+    overwriteCsvBtn.style.display = 'inline-block';
+    overwriteCsvBtn.addEventListener('click', () => {
+      const csv = db.serializeCsvMap(gameMap);
+      fetch(`/api/csv-maps/${encodeURIComponent(currentCsvFile)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csv }),
+      }).then((res) => {
+        if (!res.ok) alert('Fehler beim Speichern');
+      });
+    });
+  } else {
+    overwriteCsvBtn.style.display = 'none';
+  }
   loadMapCsvInput.addEventListener('change', loadMapCsv);
 
 

--- a/templates/map2.html
+++ b/templates/map2.html
@@ -96,6 +96,7 @@
       <button id="loadMapBtn">Load Map</button>
       <button id="loadMapCsvBtn">Load CSV</button>
       <button id="saveMapCsv">Download CSV</button>
+      <button id="overwriteMapCsv">CSV überschreiben</button>
       <input type="file" id="loadMapCsv" style="display:none" accept="text/csv" />
     </div>
     <button id="calcPathBtn">Optimal Pathfinder</button>


### PR DESCRIPTION
## Summary
- allow overwriting existing CSV maps via new API endpoint
- show `CSV überschreiben` button when editing a map loaded from CSV
- support saving edits back to original CSV file
- document new workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687437043958833183984ce5bc65f451