### PR TITLE
Stop car at mouse target

### DIFF
--- a/static/src/main.js
+++ b/static/src/main.js
@@ -361,6 +361,12 @@ function updateMouseFollow() {
     car.keys[diff > 0 ? 'ArrowRight' : 'ArrowLeft'] = true;
   } else if (dist > 10) {
     car.keys.ArrowUp = true;
+  } else {
+    // Stop immediately when close enough to the target
+    car.velocity = 0;
+    car.angularVelocity = 0;
+    car.acceleration = 0;
+    car.angularAcceleration = 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the car halts instantly once close to the mouse when in mouse follow mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68743bc2c5588331858cf81f2891112f