### PR TITLE
Stop car when mouse inside hitbox

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -126,6 +126,23 @@ export class Car {
     };
   }
 
+  pointInHitbox(px, py) {
+    const cx = this.posX + this.imgWidth / 2;
+    const cy = this.posY + this.imgHeight / 2;
+    const cos = Math.cos(-this.rotation);
+    const sin = Math.sin(-this.rotation);
+    const localX = (px - cx) * cos - (py - cy) * sin + this.imgWidth / 2;
+    const localY = (px - cx) * sin + (py - cy) * cos + this.imgHeight / 2;
+    const offsetX = (this.imgWidth - this.hitboxWidth) / 2;
+    const offsetY = (this.imgHeight - this.hitboxHeight) / 2;
+    return (
+      localX >= offsetX &&
+      localX <= offsetX + this.hitboxWidth &&
+      localY >= offsetY &&
+      localY <= offsetY + this.hitboxHeight
+    );
+  }
+
   drawHitbox() {
     const corners = this.getRotatedCorners(this.posX, this.posY);
     this.ctx.strokeStyle = 'red';

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -349,6 +349,14 @@ canvas.addEventListener('wheel', (e) => {
 
 function updateMouseFollow() {
   if (!mouseTarget) return;
+  if (car.pointInHitbox(mouseTarget.x, mouseTarget.y)) {
+    for (const k of Object.keys(car.keys)) car.keys[k] = false;
+    car.velocity = 0;
+    car.angularVelocity = 0;
+    car.acceleration = 0;
+    car.angularAcceleration = 0;
+    return;
+  }
   const cx = car.posX + car.imgWidth / 2;
   const cy = car.posY + car.imgHeight / 2;
   const angle = Math.atan2(mouseTarget.y - cy, mouseTarget.x - cx);


### PR DESCRIPTION
## Summary
- add `pointInHitbox` helper in `Car`
- stop the car in mouse-follow mode when the pointer is inside the hitbox

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874b03b5c08833188ea6fd00874bd5c