### PR TITLE
Show map overview before editing

### DIFF
--- a/server.py
+++ b/server.py
@@ -123,12 +123,22 @@ def sequences_api():
         return jsonify(load_seq_list())
 
 
-@app.route('/api/csv-maps/<filename>', methods=['PUT'])
+@app.route('/api/csv-maps/<filename>', methods=['PUT', 'DELETE'])
 def update_csv_map(filename):
     secure_name = secure_filename(filename)
     path = os.path.join(CSV_MAPS_FOLDER, secure_name)
+
+    if request.method == 'DELETE':
+        if os.path.exists(path):
+            os.remove(path)
+        maps_list = load_csv_map_list()
+        maps_list = [m for m in maps_list if m['file'] != secure_name]
+        save_csv_map_list(maps_list)
+        return '', 204
+
     if not os.path.exists(path):
         return jsonify({'error': 'not found'}), 404
+
     data = request.get_json(force=True)
     csv_data = data.get('csv')
     if not csv_data:

--- a/static/src/index.js
+++ b/static/src/index.js
@@ -4,6 +4,7 @@ async function loadList() {
   const res = await fetch('/api/csv-maps');
   const maps = await res.json();
   const grid = document.getElementById('mapGrid');
+  grid.innerHTML = '';
   for (const m of maps) {
     const tile = document.createElement('div');
     tile.className = 'tile';
@@ -12,8 +13,8 @@ async function loadList() {
       <div class="name">${m.name}</div>
       <div class="meta">${new Date(m.created).toLocaleDateString()} - ${m.creator}</div>
       <div class="buttons">
-        <button class="start">Start</button>
-        <button class="edit">Edit</button>
+        <button class="edit">Bearbeiten</button>
+        <button class="delete">Löschen</button>
       </div>`;
     grid.appendChild(tile);
     const canvas = tile.querySelector('canvas');
@@ -24,12 +25,16 @@ async function loadList() {
     gm.drawGrid(ctx);
     gm.obstacles.forEach((o) => o.draw(ctx));
     if (gm.target) gm.target.draw(ctx);
-    tile.querySelector('.start').addEventListener('click', () => {
-      window.location.href = '/map2?map=/static/maps/' + encodeURIComponent(m.file);
-    });
     tile.querySelector('.edit').addEventListener('click', () => {
       window.location.href =
         '/map2?map=/static/maps/' + encodeURIComponent(m.file) + '&editor=1';
+    });
+    tile.querySelector('.delete').addEventListener('click', async () => {
+      if (!confirm('Diese Karte wirklich löschen?')) return;
+      await fetch('/api/csv-maps/' + encodeURIComponent(m.file), {
+        method: 'DELETE',
+      });
+      loadList();
     });
   }
 }

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -11,6 +11,6 @@
 <body>
   <h1>Virtual Ares</h1>
   <a href="/sequence">Befehlseingabe</a>
-  <a href="/map2?editor=1">Karteneditor</a>
-</body>
+  <a href="/maps">Karteneditor</a>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- update landing page link for the editor to point to `/maps`
- add delete capability for CSV maps in the backend
- show stored maps in a grid with `Bearbeiten` and `Löschen` buttons

## Testing
- `npm test`
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_6874b43903cc8331b3491dedf68aee63