### PR TITLE
Add sensor-based conditional actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ database for storing maps has been removed, so all map management now happens
 through file download and upload only. When editing a map that was loaded from
 the server's CSV list you can use the **CSV überschreiben** button to overwrite
 the original file instead of downloading a new one.
+
+## Command sequences
+
+Sequences of actions can be stored under `static/sequences`. Each line of a
+sequence normally consists of an action and a duration in seconds:
+
+```
+forward,1
+left,0.5
+```
+
+It is also possible to use conditional statements based on the sensor values.
+An example line looks like this:
+
+```
+if front < 50 then backward 1 else forward 1
+```
+
+The available sensor names are `front` (red LiDAR), `left`, `right` and `back`
+(blue sonar). When running the sequence the condition is evaluated and the
+corresponding branch is executed.

--- a/static/src/car.js
+++ b/static/src/car.js
@@ -71,6 +71,12 @@ export class Car {
       right: 'ArrowRight',
       stop: null,
     };
+
+    // Last measured sensor distances
+    this.frontDistance = Infinity;
+    this.leftDistance = Infinity;
+    this.rightDistance = Infinity;
+    this.rearDistance = Infinity;
   }
 
   setKeysFromAction(action) {


### PR DESCRIPTION
## Summary
- allow if-else conditions in command sequences
- expose last measured sensor distances on the car
- make main loop store sensor distances for later use
- evaluate conditions when executing sequences
- document the new sequence syntax

## Testing
- `pytest`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874b5cc83e883318efda4ba1ad9fe38