### PR TITLE
Add SLAM display option

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -317,7 +317,7 @@ export class Car {
     return [segment, ...rest];
   }
 
-  drawKegel(x, y, length, angle, color, baseWidth) {
+  drawKegel(x, y, length, angle, color, baseWidth, ctx = this.ctx) {
     x *= this.scale;
     y *= this.scale;
     baseWidth *= this.scale;
@@ -335,7 +335,7 @@ export class Car {
     const finalAngle = angle + this.rotation;
     const segments = this.castRayPath(fx, fy, finalAngle, length);
     let total = 0;
-    this.ctx.fillStyle = color;
+    ctx.fillStyle = color;
     for (const seg of segments) {
       const sx = seg.x;
       const sy = seg.y;
@@ -345,12 +345,12 @@ export class Car {
       const leftY = ey + (Math.sin(seg.angle + Math.PI / 2) * baseWidth) / 2;
       const rightX = ex + (Math.cos(seg.angle - Math.PI / 2) * baseWidth) / 2;
       const rightY = ey + (Math.sin(seg.angle - Math.PI / 2) * baseWidth) / 2;
-      this.ctx.beginPath();
-      this.ctx.moveTo(sx, sy);
-      this.ctx.lineTo(leftX, leftY);
-      this.ctx.lineTo(rightX, rightY);
-      this.ctx.closePath();
-      this.ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(sx, sy);
+      ctx.lineTo(leftX, leftY);
+      ctx.lineTo(rightX, rightY);
+      ctx.closePath();
+      ctx.fill();
       total += seg.length;
     }
 

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -20,6 +20,10 @@ const calcPathBtn = document.getElementById('calcPathBtn');
 const toggleHitboxesBtn = document.getElementById('toggleHitboxes');
 const findCarBtn = document.getElementById('findCarBtn');
 const canvasContainer = document.getElementById('canvasContainer');
+const slamCheckbox = document.getElementById('slamMode');
+const slamCanvas = document.getElementById('slamCanvas');
+const slamCtx = slamCanvas.getContext('2d');
+let slamMode = false;
 const saveMapCsvBtn = document.getElementById('saveMapCsv');
 const overwriteCsvBtn = document.getElementById('overwriteMapCsv');
 const connectCornersBtn = document.getElementById('connectCorners');
@@ -49,11 +53,31 @@ const gyroEl = document.getElementById('gyro');
 const cellCmInput = document.getElementById('gridCellCm');
 const widthCmInput = document.getElementById('gridWidth');
 const heightCmInput = document.getElementById('gridHeight');
+const params = new URLSearchParams(window.location.search);
+const csvMapUrl = params.get('map');
+const editorMode = params.has('editor');
 
 if (controlModeSelect) {
   controlModeSelect.addEventListener('change', () => {
     controlMode = controlModeSelect.value;
     car.autopilot = controlMode === 'mouse';
+  });
+}
+
+if (slamCheckbox) {
+  if (!editorMode) slamCheckbox.parentElement.style.display = 'none';
+  slamCheckbox.addEventListener('change', () => {
+    slamMode = slamCheckbox.checked;
+    if (slamMode) {
+      slamCanvas.width = canvas.width;
+      slamCanvas.height = canvas.height;
+      slamCanvas.style.display = 'block';
+      slamCtx.fillStyle = 'rgba(128,128,128,0.5)';
+      slamCtx.fillRect(0, 0, slamCanvas.width, slamCanvas.height);
+    } else {
+      slamCanvas.style.display = 'none';
+      slamCtx.clearRect(0, 0, slamCanvas.width, slamCanvas.height);
+    }
   });
 }
 
@@ -214,9 +238,6 @@ const initialRows = Math.max(
 let gameMap = new GameMap(initialCols, initialRows, CELL_SIZE);
 let previewSize;
 updateObstacleOptions();
-const params = new URLSearchParams(window.location.search);
-const csvMapUrl = params.get('map');
-const editorMode = params.has('editor');
 let currentCsvFile = null;
 if (!editorMode) {
   const e1 = document.getElementById('editorTools');
@@ -321,11 +342,18 @@ function updateObstacleOptions() {
 function resizeCanvas() {
   canvas.width = gameMap.cols * CELL_SIZE;
   canvas.height = gameMap.rows * CELL_SIZE;
+  slamCanvas.width = canvas.width;
+  slamCanvas.height = canvas.height;
+  if (slamMode) {
+    slamCtx.fillStyle = 'rgba(128,128,128,0.5)';
+    slamCtx.fillRect(0, 0, slamCanvas.width, slamCanvas.height);
+  }
   updateTransform();
 }
 
 function updateTransform() {
   canvas.style.transform = `translate(${-translateX}px, ${-translateY}px) scale(${zoomScale})`;
+  slamCanvas.style.transform = `translate(${-translateX}px, ${-translateY}px) scale(${zoomScale})`;
 }
 
 function paintCell(x, y) {
@@ -397,6 +425,13 @@ function connectCorners() {
 }
 
 window.addEventListener('resize', resizeCanvas);
+
+function revealCone(x, y, length, angle, baseWidth) {
+  slamCtx.save();
+  slamCtx.globalCompositeOperation = 'destination-out';
+  car.drawKegel(x, y, length, angle, '#000', baseWidth, slamCtx);
+  slamCtx.restore();
+}
 
 function updatePreview() {
   updateObstacleOptions();
@@ -613,6 +648,26 @@ function loop() {
   const br1 = car.drawKegel(91, 7, 150, -Math.PI / 2, 'blue', 8);
   const br2 = car.drawKegel(97, 7, 150, -Math.PI / 2, 'blue', 8);
   const bb = car.drawKegel(143, 37, 150, 0, 'blue', 8);
+  if (slamMode) {
+    revealCone(18, 40, 700, Math.PI, 6);
+    revealCone(45, 40, 400, Math.PI, 140);
+    for (const [x, y] of [
+      [65, 7],
+      [72, 7],
+      [91, 7],
+      [97, 7],
+    ])
+      revealCone(x, y, 150, -Math.PI / 2, 8);
+    for (const [x, y] of [
+      [64, 74],
+      [71, 74],
+      [90, 74],
+      [97, 74],
+    ])
+      revealCone(x, y, 150, Math.PI / 2, 8);
+    revealCone(143, 37, 150, 0, 8);
+    revealCone(143, 43, 150, 0, 8);
+  }
   car.frontDistance = car.redConeLength;
   car.leftDistance = Math.min(bl1, bl2);
   car.rightDistance = Math.min(br1, br2);

--- a/templates/map2.html
+++ b/templates/map2.html
@@ -50,6 +50,12 @@
         overflow: hidden;
         position: relative;
       }
+      #slamCanvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+        pointer-events: none;
+      }
       canvas {
         display: block;
         background: #fff;
@@ -151,6 +157,7 @@
       </div>
       <button id="calcPathBtn">Optimal Pathfinder</button>
       <button id="toggleHitboxes">Hitboxen anzeigen</button>
+      <label>SLAM <input type="checkbox" id="slamMode" /></label>
       <button id="findCarBtn">Auto finden</button>
       <label>Befehlsfolge:
         <select id="sequenceSelect"></select>
@@ -198,6 +205,7 @@
       <input type="file" id="loadMapCsv" style="display:none" accept="text/csv" />
     <div id="canvasContainer">
       <canvas id="canvas"></canvas>
+      <canvas id="slamCanvas"></canvas>
     </div>
     <script
       type="module"


### PR DESCRIPTION
## Summary
- add SLAM overlay checkbox and canvas on map page
- allow Car.drawKegel to render on any canvas context
- implement SLAM overlay logic in main.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874b9c3737483319d2d7f78d332e8d8