### PR TITLE
Fix SLAM ray-casting depth check

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -274,7 +274,6 @@ export class Car {
 
   castRayPath(fx, fy, angle, length, depth = 0) {
     if (length <= 0 || depth > 3) return [];
-    if (length <= 0 || depth > 1) return [];
 
     let minDist = length;
     let bestNormal = null;
@@ -356,7 +355,6 @@ export class Car {
 
     const first = segments.length ? segments[0].length : length;
     return first;
-    return total;
   }
 
   draw(canvasWidth, canvasHeight) {


### PR DESCRIPTION
## Summary
- fix slam path tracing by removing duplicate depth check
- clean up unreachable return in drawKegel

## Testing
- `npm test`
- `python server.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6874bc0722e483318b354a6be3360041