### PR TITLE
Fix server URLs in config and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,18 @@ This repository contains a small browser based car simulator. The page `map2.htm
 
 ## Running the simulation
 
-Run the Flask application which serves both the HTML interface and the API endpoints:
+Run the Flask application which serves both the HTML interface and the API
+endpoints:
 
 ```bash
 python server.py
 ```
 
-Then open `http://127.0.0.1:5000/` in your browser. The Flask server exposes the following services:
+Then open `http://127.0.0.1:5000/` in your browser. The server exposes the
+following services:
 - `http://127.0.0.1:5000/api/car` for telemetry data from the simulator.
 - `http://127.0.0.1:5000/api/control` for remote control commands.
-   Then navigate to `http://localhost:8000/map2.html`.
-
-2. Start the Flask backend which provides the required API endpoints:
-
-   ```bash
-   python server.py
-   ```
-
-    This exposes the following services:
-    - `http://127.0.0.1:5001/api/car` for telemetry data from the simulator.
-    - `http://localhost:5002/api/control` for remote control commands.
-
-Without these servers the related features of the HTML page will not work.
+The map editor is available at `http://127.0.0.1:5000/map2`.
 
 ## Saving and loading maps
 

--- a/static/src/config.js
+++ b/static/src/config.js
@@ -1,2 +1,4 @@
-export const CONTROL_API_URL = 'http://localhost:5002/api/control';
-export const TELEMETRY_API_URL = 'http://127.0.0.1:5001/api/car';
+// Use relative URLs so the frontend works with the Flask server on port 5000
+// without any additional configuration.
+export const CONTROL_API_URL = '/api/control';
+export const TELEMETRY_API_URL = '/api/car';


### PR DESCRIPTION
## Summary
- use relative URLs for control and telemetry APIs
- update README run instructions

## Testing
- `npm test`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874bde2e4ac833183c01c2fa3455b1f