### PR TITLE
Improve nested drag and drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,8 @@ for 3 forward 1
 
 This executes the `forward` command three times for one second each. In the
 sequence editor this can be added via the **Wiederholung hinzufügen** button.
+
+Steps can be rearranged and nested via drag & drop. Simply drag an action or
+condition onto the desired target list, e.g. into the *then* or *else* block or
+inside a loop. Empty lists are shown with a dashed border to indicate that you
+can drop items there.

--- a/static/src/sequenceEditor.js
+++ b/static/src/sequenceEditor.js
@@ -120,14 +120,14 @@ function createIfNode() {
   const thenDiv = document.createElement('div');
   thenDiv.textContent = 'dann:';
   const thenList = document.createElement('ul');
-  thenList.className = 'steps then';
+  thenList.className = 'steps then nested';
   thenDiv.appendChild(thenList);
   li.appendChild(thenDiv);
 
   const elseDiv = document.createElement('div');
   elseDiv.textContent = 'sonst:';
   const elseList = document.createElement('ul');
-  elseList.className = 'steps else';
+  elseList.className = 'steps else nested';
   elseDiv.appendChild(elseList);
   li.appendChild(elseDiv);
 
@@ -153,7 +153,7 @@ function createLoopNode() {
   header.append('for ', countInput, 'x ', del);
   li.appendChild(header);
   const inner = document.createElement('ul');
-  inner.className = 'steps';
+  inner.className = 'steps nested';
   li.appendChild(inner);
   initDrag(inner);
   del.addEventListener('click', () => li.remove());

--- a/templates/sequence.html
+++ b/templates/sequence.html
@@ -23,6 +23,15 @@
         list-style: none;
         padding-left: 20px;
         margin: 0;
+        min-height: 20px;
+      }
+      ul.steps.nested {
+        border-left: 2px dashed #555;
+        margin-left: 10px;
+        padding-left: 20px;
+      }
+      ul.steps:empty {
+        border: 1px dashed #555;
       }
       li.step {
         border: 1px solid #555;


### PR DESCRIPTION
## Summary
- allow nested lists in the sequence editor
- show dashed borders and indentation for inner lists
- document how drag & drop nesting works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874c077596c8331bc63ef68bddda4a6