### PR TITLE
Fix duplicate HTML elements in map2 template

### DIFF
--- a/templates/map2.html
+++ b/templates/map2.html
@@ -148,6 +148,7 @@
         <button id="loadMapBtn">Load Map</button>
         <button id="loadMapCsvBtn">Load CSV</button>
         <button id="saveMapCsv">Download CSV</button>
+        <button id="overwriteMapCsv">CSV überschreiben</button>
         <input
           type="file"
           id="loadMapCsv"
@@ -177,32 +178,6 @@
         accept="application/json"
       />
     </div>
-    <div class="cone-display">Rot: <span id="redLength">0</span> px</div>
-    <div class="cone-display">Grün: <span id="greenLength">0</span> px</div>
-    <div class="cone-display">Blau Links 1: <span id="blueLeft1">0</span> px</div>
-    <div class="cone-display">Blau Links 2: <span id="blueLeft2">0</span> px</div>
-    <div class="cone-display">Blau Rechts 1: <span id="blueRight1">0</span> px</div>
-    <div class="cone-display">Blau Rechts 2: <span id="blueRight2">0</span> px</div>
-    <div class="cone-display">Blau Hinten: <span id="blueBack">0</span> px</div>
-    <div class="cone-display">Geschwindigkeit: <span id="speed">0</span> px/s</div>
-    <div class="cone-display">Drehzahl: <span id="rpm">0</span> RPM</div>
-    <div class="cone-display">Gyro: <span id="gyro">0</span>°</div>
-    <div id="editorTools2">
-      <label>Size (cm):
-        <input id="gridWidth" type="number" value="6400" min="1" style="width:60px"> x
-        <input id="gridHeight" type="number" value="4800" min="1" style="width:60px">
-      </label>
-      <label>Quadrat (cm):
-        <input id="gridCellCm" type="number" value="5" min="1" max="25" style="width:60px">
-      </label>
-      <button id="setSizeBtn">Set Size</button>
-      <input type="text" id="mapName" placeholder="Map name">
-      <button id="saveMap">Download Map</button>
-      <button id="loadMapBtn">Load Map</button>
-      <button id="loadMapCsvBtn">Load CSV</button>
-      <button id="saveMapCsv">Download CSV</button>
-      <button id="overwriteMapCsv">CSV überschreiben</button>
-      <input type="file" id="loadMapCsv" style="display:none" accept="text/csv" />
     <div id="canvasContainer">
       <canvas id="canvas"></canvas>
       <canvas id="slamCanvas"></canvas>


### PR DESCRIPTION
## Summary
- remove duplicate controls in `map2.html`
- keep CSV overwrite button in the main editor toolbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874c094d8e083319f42a638fff165f8