### PR TITLE
Add persistent obstacle markers for SLAM view

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -316,7 +316,16 @@ export class Car {
     return [segment, ...rest];
   }
 
-  drawKegel(x, y, length, angle, color, baseWidth, ctx = this.ctx) {
+  drawKegel(
+    x,
+    y,
+    length,
+    angle,
+    color,
+    baseWidth,
+    ctx = this.ctx,
+    hitCallback,
+  ) {
     x *= this.scale;
     y *= this.scale;
     baseWidth *= this.scale;
@@ -354,6 +363,12 @@ export class Car {
     }
 
     const first = segments.length ? segments[0].length : length;
+    if (hitCallback && segments.length && segments[0].length < length) {
+      const seg = segments[0];
+      const hx = seg.x + Math.cos(seg.angle) * seg.length;
+      const hy = seg.y + Math.sin(seg.angle) * seg.length;
+      hitCallback(hx, hy, first);
+    }
     return first;
   }
 

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -455,10 +455,26 @@ function connectCorners() {
 window.addEventListener('resize', resizeCanvas);
 
 function revealCone(x, y, length, angle, baseWidth) {
+  let hit = null;
   slamCtx.save();
   slamCtx.globalCompositeOperation = 'destination-out';
-  car.drawKegel(x, y, length, angle, '#000', baseWidth, slamCtx);
+  car.drawKegel(
+    x,
+    y,
+    length,
+    angle,
+    '#000',
+    baseWidth,
+    slamCtx,
+    (hx, hy) => (hit = { x: hx, y: hy }),
+  );
   slamCtx.restore();
+  if (hit) {
+    slamCtx.fillStyle = 'red';
+    slamCtx.beginPath();
+    slamCtx.arc(hit.x, hit.y, 3, 0, 2 * Math.PI);
+    slamCtx.fill();
+  }
 }
 
 function revealCar() {


### PR DESCRIPTION
## Summary
- extend `Car.drawKegel` with optional hit callback to obtain sensor hit points
- enhance `revealCone` in `main.js` to draw a red dot at the detected wall position

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f4bdcc6c833192fce9adbf6437d6