### PR TITLE
Add while loops and reusable sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,12 @@ Steps can be rearranged and nested via drag & drop. Simply drag an action or
 condition onto the desired target list, e.g. into the *then* or *else* block or
 inside a loop. Empty lists are shown with a dashed border to indicate that you
 can drop items there.
+
+The editor also supports **while** loops with sensor conditions. A loop will
+continue executing its inner steps as long as the defined sensor comparison is
+true (e.g. `while front > 20`).
+
+Saved sequences can be reused inside new ones. When adding an "Ablauf einfügen"
+block the editor stores only a reference to the selected sequence. During
+execution the referenced file is loaded and its steps are executed. This allows
+modularizing complex behaviours.

--- a/templates/sequence.html
+++ b/templates/sequence.html
@@ -56,6 +56,8 @@
       <button id="addStep">Schritt hinzufügen</button>
       <button id="addCond">Bedingung hinzufügen</button>
       <button id="addLoop">Wiederholung hinzufügen</button>
+      <button id="addWhile">While hinzufügen</button>
+      <button id="addCall">Ablauf einfügen</button>
       <button id="saveSeq">Speichern</button>
     </div>
     <p>Schritte können per Drag &amp; Drop sortiert werden.</p>


### PR DESCRIPTION
## Summary
- support while-loops and calling existing sequences in the sequence editor
- load available sequence files for use inside other sequences
- expand runtime to handle JSON sequences with while/call blocks
- document new features in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f6a2a6d08331b6619576bdd9bf6c