### PR TITLE
Add load and edit support for sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ Saved sequences can be reused inside new ones. When adding an "Ablauf einfügen"
 block the editor stores only a reference to the selected sequence. During
 execution the referenced file is loaded and its steps are executed. This allows
 modularizing complex behaviours.
+
+Existing sequences saved in JSON format can be loaded back into the editor
+through the new **Vorhanden** drop-down and the **Laden** button. This makes it
+possible to edit and extend previously created command sequences.

--- a/templates/sequence.html
+++ b/templates/sequence.html
@@ -59,6 +59,11 @@
       <button id="addWhile">While hinzufügen</button>
       <button id="addCall">Ablauf einfügen</button>
       <button id="saveSeq">Speichern</button>
+      <label
+        >Vorhanden:
+        <select id="seqLoadSelect"></select>
+      </label>
+      <button id="loadSeq">Laden</button>
     </div>
     <p>Schritte können per Drag &amp; Drop sortiert werden.</p>
     <ul id="steps" class="steps"></ul>


### PR DESCRIPTION
## Summary
- allow users to select and load saved sequences on the editor page
- extend sequence editor to build UI from loaded JSON steps
- document the new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f81c0bf08331b981dd75e4ccd1d2