### PR TITLE
Fix saving sequences with loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ can drop items there.
 
 The editor also supports **while** loops with sensor conditions. A loop will
 continue executing its inner steps as long as the defined sensor comparison is
-true (e.g. `while front > 20`).
+true (e.g. `while front > 20`). Sequences that contain such loops or other
+conditional logic are stored in JSON format. When saving a sequence with loops,
+the editor automatically selects JSON to avoid API errors.
 
 Saved sequences can be reused inside new ones. When adding an "Ablauf einfügen"
 block the editor stores only a reference to the selected sequence. During

--- a/static/src/sequenceEditor.js
+++ b/static/src/sequenceEditor.js
@@ -316,6 +316,10 @@ function collectSteps(list) {
   return steps;
 }
 
+function hasComplex(steps) {
+  return steps.some((s) => s.if || s.loop || s.while || s.call);
+}
+
 addBtn.addEventListener('click', () => rootList.appendChild(createActionNode()));
 addCondBtn.addEventListener('click', () => rootList.appendChild(createIfNode()));
 if (addLoopBtn) addLoopBtn.addEventListener('click', () => rootList.appendChild(createLoopNode()));
@@ -352,7 +356,7 @@ if (loadBtn)
 
 saveBtn.addEventListener('click', async () => {
   const name = document.getElementById('seqName').value.trim();
-  const format = document.getElementById('seqFormat').value;
+  let format = document.getElementById('seqFormat').value;
   if (!name) {
     alert('Name fehlt');
     return;
@@ -361,6 +365,10 @@ saveBtn.addEventListener('click', async () => {
   if (!steps.length) {
     alert('Keine Schritte');
     return;
+  }
+  if (hasComplex(steps) && format !== 'json') {
+    format = 'json';
+    document.getElementById('seqFormat').value = 'json';
   }
   const res = await fetch('/api/sequences', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- document that sequences with loops are saved in JSON format
- choose JSON automatically in the sequence editor when steps contain loops, conditions or calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687529864d448331b1779bbe3267a025