### PR TITLE
Add sequence management interface

### DIFF
--- a/static/src/sequenceEditor.js
+++ b/static/src/sequenceEditor.js
@@ -376,9 +376,32 @@ if (addCallBtn) addCallBtn.addEventListener('click', () => {
   rootList.appendChild(createCallNode());
 });
 
-loadSequenceList();
+await loadSequenceList();
 initDrag(rootList);
 rootList.appendChild(createActionNode());
+
+const params = new URLSearchParams(window.location.search);
+const fileParam = params.get('file');
+if (fileParam) {
+  const entry = sequenceList.find((s) => s.file === fileParam);
+  if (entry) {
+    const res = await fetch('/static/sequences/' + encodeURIComponent(entry.file));
+    if (res.ok) {
+      let steps;
+      const fmt = entry.format || (entry.file.endsWith('.json') ? 'json' : entry.file.endsWith('.ros') ? 'ros' : 'csv');
+      if (fmt === 'json') {
+        steps = await res.json();
+      } else {
+        const text = await res.text();
+        steps = parseTextSequence(text, fmt);
+      }
+      document.getElementById('seqName').value = entry.name;
+      document.getElementById('seqFormat').value = fmt;
+      rootList.innerHTML = '';
+      buildSteps(steps, rootList);
+    }
+  }
+}
 
 if (loadBtn)
   loadBtn.addEventListener('click', async () => {

--- a/static/src/sequenceList.js
+++ b/static/src/sequenceList.js
@@ -1,0 +1,39 @@
+async function loadList() {
+  const res = await fetch('/api/sequences');
+  const sequences = await res.json();
+  const grid = document.getElementById('seqGrid');
+  grid.innerHTML = '';
+  for (const s of sequences) {
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    tile.innerHTML = `
+      <div class="name">${s.name}</div>
+      <div class="meta">${new Date(s.created).toLocaleDateString()}</div>
+      <div class="buttons">
+        <button class="edit">Bearbeiten</button>
+        <button class="rename">Umbenennen</button>
+        <button class="delete">Löschen</button>
+      </div>`;
+    grid.appendChild(tile);
+    tile.querySelector('.edit').addEventListener('click', () => {
+      window.location.href = '/sequence?file=' + encodeURIComponent(s.file);
+    });
+    tile.querySelector('.rename').addEventListener('click', async () => {
+      const newName = prompt('Neuer Name:', s.name);
+      if (!newName) return;
+      await fetch('/api/sequences/' + encodeURIComponent(s.file), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      loadList();
+    });
+    tile.querySelector('.delete').addEventListener('click', async () => {
+      if (!confirm('Diesen Ablauf wirklich löschen?')) return;
+      await fetch('/api/sequences/' + encodeURIComponent(s.file), { method: 'DELETE' });
+      loadList();
+    });
+  }
+}
+
+loadList();

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -11,6 +11,7 @@
 <body>
   <h1>Virtual Ares</h1>
   <a href="/sequence">Befehlseingabe</a>
+  <a href="/sequences">Abläufe</a>
   <a href="/maps">Karteneditor</a>
   </body>
 </html>

--- a/templates/sequences.html
+++ b/templates/sequences.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>Virtual Ares - Abläufe</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #111;
+      color: #eee;
+      margin: 0;
+    }
+    #seqGrid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 20px;
+      padding: 20px;
+    }
+    .tile {
+      background: #222;
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .buttons {
+      display: flex;
+      gap: 5px;
+      margin-top: 5px;
+    }
+    button {
+      padding: 5px 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1 style="text-align:center;padding:10px 0;">Abläufe</h1>
+  <div id="seqGrid"></div>
+  <script type="module" src="{{ url_for('static', filename='src/sequenceList.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add page to view saved sequences similar to map cards
- link the new page from the landing page
- support renaming and deleting sequences via new API endpoints
- support opening a sequence by file parameter in the editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753d8284a8833197ed77345d7d4c8b