### PR TITLE
Add play mode and sensor toggle

### DIFF
--- a/static/src/index.js
+++ b/static/src/index.js
@@ -13,6 +13,7 @@ async function loadList() {
       <div class="name">${m.name}</div>
       <div class="meta">${new Date(m.created).toLocaleDateString()} - ${m.creator}</div>
       <div class="buttons">
+        <button class="play">Spielen</button>
         <button class="edit">Bearbeiten</button>
         <button class="delete">Löschen</button>
       </div>`;
@@ -25,6 +26,10 @@ async function loadList() {
     gm.drawGrid(ctx);
     gm.obstacles.forEach((o) => o.draw(ctx));
     if (gm.target) gm.target.draw(ctx);
+    tile.querySelector('.play').addEventListener('click', () => {
+      window.location.href =
+        '/map2?map=/static/maps/' + encodeURIComponent(m.file);
+    });
     tile.querySelector('.edit').addEventListener('click', () => {
       window.location.href =
         '/map2?map=/static/maps/' + encodeURIComponent(m.file) + '&editor=1';

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -296,6 +296,10 @@ if (!editorMode) {
   const e2 = document.getElementById('editorTools2');
   if (e1) e1.style.display = 'none';
   if (e2) e2.style.display = 'none';
+} else {
+  document.querySelectorAll('.cone-display').forEach((el) => {
+    el.style.display = 'none';
+  });
 }
 if (csvMapUrl) {
   if (csvMapUrl.startsWith('/static/maps/')) {


### PR DESCRIPTION
## Summary
- hide cone display values when in editor mode
- add Play button to map list for easier separation between play and editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68753f4217088331b51886c17e01a086