### PR TITLE
Add telemetry state and map grid API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ python server.py
 
 Then open `http://127.0.0.1:5000/` in your browser. The server exposes the
 following services:
-- `http://127.0.0.1:5000/api/car` for telemetry data from the simulator.
+- `http://127.0.0.1:5000/api/car` for reading or sending telemetry data.
 - `http://127.0.0.1:5000/api/control` for remote control commands.
-The map editor is available at `http://127.0.0.1:5000/map2`.
+- `http://127.0.0.1:5000/api/grid` for the current occupancy grid.
+The map editor is available at `http://127.0.0.1:5000/map2`. A simple view of the
+API output can be found at `http://127.0.0.1:5000/status`.
 
 ## Saving and loading maps
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>API Daten</title>
+  <style>
+    body{font-family:Arial,sans-serif;background:#111;color:#eee;margin:0;padding:20px}
+    pre{background:#222;padding:10px}
+  </style>
+</head>
+<body>
+  <h1>API Daten</h1>
+  <h2>Zustand</h2>
+  <pre id="state"></pre>
+  <h2>Kartendaten</h2>
+  <pre id="grid"></pre>
+<script>
+async function refresh(){
+  const sRes=await fetch('/api/car');
+  const s=await sRes.json();
+  document.getElementById('state').textContent=JSON.stringify(s,null,2);
+  const gRes=await fetch('/api/grid');
+  if(gRes.ok){
+    const g=await gRes.json();
+    document.getElementById('grid').textContent=JSON.stringify(g,null,2);
+  }
+}
+setInterval(refresh,1000);
+refresh();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose latest telemetry data with GET /api/car
- provide occupancy grid at /api/grid
- update map handling to track current map and grid
- add simple status page showing API output
- document new endpoints in README

## Testing
- `npm test`
- `npx prettier --write "static/src/**/*.js"` (manual formatting)


------
https://chatgpt.com/codex/tasks/task_e_6875414b1fe88331962db1cf11367935