### PR TITLE
Enable renaming map entries in tile view

### DIFF
--- a/server.py
+++ b/server.py
@@ -207,9 +207,29 @@ def update_csv_map(filename):
         return jsonify({'error': 'not found'}), 404
 
     data = request.get_json(force=True)
+    new_name = data.get('name')
     csv_data = data.get('csv')
-    if not csv_data:
+
+    if new_name and not csv_data:
+        base, ext = os.path.splitext(secure_name)
+        new_file = secure_filename(new_name)
+        if not new_file.endswith('.csv'):
+            new_file += '.csv'
+        new_path = os.path.join(CSV_MAPS_FOLDER, new_file)
+        os.rename(path, new_path)
+        maps_list = load_csv_map_list()
+        for entry in maps_list:
+            if entry['file'] == secure_name:
+                entry['file'] = new_file
+                entry['name'] = new_name
+                entry['created'] = datetime.utcnow().isoformat()
+                break
+        save_csv_map_list(maps_list)
+        return jsonify({'file': new_file}), 200
+
+    if csv_data is None:
         return jsonify({'error': 'missing csv'}), 400
+
     with open(path, 'w') as f:
         f.write(csv_data)
     maps_list = load_csv_map_list()

--- a/static/src/index.js
+++ b/static/src/index.js
@@ -15,6 +15,7 @@ async function loadList() {
       <div class="buttons">
         <button class="play">Spielen</button>
         <button class="edit">Bearbeiten</button>
+        <button class="rename">Umbenennen</button>
         <button class="delete">Löschen</button>
       </div>`;
     grid.appendChild(tile);
@@ -33,6 +34,16 @@ async function loadList() {
     tile.querySelector('.edit').addEventListener('click', () => {
       window.location.href =
         '/map2?map=/static/maps/' + encodeURIComponent(m.file) + '&editor=1';
+    });
+    tile.querySelector('.rename').addEventListener('click', async () => {
+      const newName = prompt('Neuer Name:', m.name);
+      if (!newName) return;
+      await fetch('/api/csv-maps/' + encodeURIComponent(m.file), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      loadList();
     });
     tile.querySelector('.delete').addEventListener('click', async () => {
       if (!confirm('Diese Karte wirklich löschen?')) return;


### PR DESCRIPTION
## Summary
- add rename button to map selection grid
- support renaming CSV map files via API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687541d4b4b08331b015d9546780671c