### PR TITLE
Fix status page grid and link from dashboard

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -13,5 +13,6 @@
   <a href="/sequence">Befehlseingabe</a>
   <a href="/sequences">Abläufe</a>
   <a href="/maps">Karteneditor</a>
+  <a href="/status">Status</a>
   </body>
 </html>

--- a/templates/status.html
+++ b/templates/status.html
@@ -20,9 +20,12 @@ async function refresh(){
   const s=await sRes.json();
   document.getElementById('state').textContent=JSON.stringify(s,null,2);
   const gRes=await fetch('/api/grid');
+  const gridEl=document.getElementById('grid');
   if(gRes.ok){
     const g=await gRes.json();
-    document.getElementById('grid').textContent=JSON.stringify(g,null,2);
+    gridEl.textContent=JSON.stringify(g,null,2);
+  }else{
+    gridEl.textContent='Keine Kartendaten verf\u00fcgbar';
   }
 }
 setInterval(refresh,1000);


### PR DESCRIPTION
## Summary
- show message if no map grid is available on status page
- add link to status page from the landing dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875433e9c048331978c35da25caeedc