### PR TITLE
Show SLAM map on status page

### DIFF
--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ telemetry_log = []
 latest_telemetry = None
 current_map = None
 current_grid = None
+current_slam_map = None
 
 
 @app.route('/')
@@ -332,6 +333,21 @@ def grid():
     if current_grid is None:
         return jsonify({'error': 'no map'}), 404
     return jsonify(current_grid)
+
+
+@app.route('/api/slam-map')
+def slam_map():
+    if current_slam_map is None:
+        # default simple map: return current_grid if available
+        if current_grid is None:
+            return jsonify({'gridSize': {'width': 0, 'height': 0}, 'cells': []})
+        else:
+            h = len(current_grid)
+            w = len(current_grid[0]) if h else 0
+            return jsonify({'gridSize': {'width': w, 'height': h}, 'cells': current_grid})
+    h = len(current_slam_map)
+    w = len(current_slam_map[0]) if h else 0
+    return jsonify({'gridSize': {'width': w, 'height': h}, 'cells': current_slam_map})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/src/status.js
+++ b/static/src/status.js
@@ -1,5 +1,7 @@
 const canvas = document.getElementById('mapCanvas');
 const ctx = canvas.getContext('2d');
+const slamCanvas = document.getElementById('slamMapCanvas');
+const slamCtx = slamCanvas.getContext('2d');
 
 const CELL = 10; // pixel size of each grid cell
 const cols = Math.floor(canvas.width / CELL);
@@ -70,5 +72,28 @@ async function refresh() {
   drawGrid();
 }
 
+async function updateSlamMap() {
+  const res = await fetch('/api/slam-map');
+  if (!res.ok) return;
+  const data = await res.json();
+  const w = data.gridSize.width;
+  const h = data.gridSize.height;
+  if (!w || !h) return;
+  const cell = Math.floor(Math.min(slamCanvas.width / w, slamCanvas.height / h));
+  slamCanvas.width = w * cell;
+  slamCanvas.height = h * cell;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const val = data.cells[y][x];
+      if (val === 0) slamCtx.fillStyle = '#cccccc';
+      else if (val === 1) slamCtx.fillStyle = '#ffffff';
+      else if (val === 2) slamCtx.fillStyle = '#000000';
+      slamCtx.fillRect(x * cell, y * cell, cell, cell);
+    }
+  }
+}
+
 setInterval(refresh, 1000);
+setInterval(updateSlamMap, 1000);
 refresh();
+updateSlamMap();

--- a/templates/status.html
+++ b/templates/status.html
@@ -15,6 +15,8 @@
   <h2>Kartendaten</h2>
   <canvas id="mapCanvas" width="640" height="480" style="background:#222;"></canvas>
   <pre id="grid"></pre>
-<script type="module" src="{{ url_for('static', filename='src/status.js') }}"></script>
+  <h2>SLAM-Karte (Live)</h2>
+  <canvas id="slamMapCanvas" width="500" height="500" style="background:#222;"></canvas>
+  <script type="module" src="{{ url_for('static', filename='src/status.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add SLAM map canvas to `status.html`
- fetch `/api/slam-map` in `status.js` and draw occupancy grid
- expose new Flask route `/api/slam-map`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875477dfebc8331bf0b28115dad6c7b