### PR TITLE
Implement angle-based steering

### DIFF
--- a/static/src/autopilot/send.js
+++ b/static/src/autopilot/send.js
@@ -1,12 +1,14 @@
 import { CONTROL_API_URL } from '../config.js';
 
-export function sendAction(car, action) {
-  car.setKeysFromAction(action);
+export function sendAction(car, action, value = null) {
+  car.setKeysFromAction(action, value);
   // Fire and forget but return the promise for optional awaiting
   return fetch(CONTROL_API_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action }),
+    body: JSON.stringify(
+      value == null ? { action } : { action, value },
+    ),
   }).catch((err) => {
     console.error('autopilot send failed', err);
   });

--- a/static/src/car.js
+++ b/static/src/car.js
@@ -34,13 +34,10 @@ export class Car {
     this.acceleration = 0;
     this.rotation = 0;
     this.angularVelocity = 0;
-    this.angularAcceleration = 0;
 
     this.maxSpeed = 5;
     this.accelRate = 0.2;
     this.decelRate = 0.05;
-    this.rotAccelRate = 0.0005;
-    this.rotDecelRate = 0.003;
 
     this.maxRpm = 5000;
     this.speed = 0;
@@ -77,10 +74,42 @@ export class Car {
     this.leftDistance = Infinity;
     this.rightDistance = Infinity;
     this.rearDistance = Infinity;
+
+    // Steering state in radians
+    this.steeringAngle = 0;
+    this.maxSteering = (70 * Math.PI) / 180;
+    this.steerRate = 0.02;
+    this.wheelBase = 50;
   }
 
-  setKeysFromAction(action) {
+  setKeysFromAction(action, value = null) {
     for (const k of Object.keys(this.keys)) this.keys[k] = false;
+    if (action === 'left') {
+      if (typeof value === 'number') {
+        this.steeringAngle = Math.max(
+          -this.maxSteering,
+          Math.min(this.maxSteering, (-value * Math.PI) / 180),
+        );
+      } else {
+        this.keys.ArrowLeft = true;
+      }
+      return;
+    }
+    if (action === 'right') {
+      if (typeof value === 'number') {
+        this.steeringAngle = Math.max(
+          -this.maxSteering,
+          Math.min(this.maxSteering, (value * Math.PI) / 180),
+        );
+      } else {
+        this.keys.ArrowRight = true;
+      }
+      return;
+    }
+    if (action === 'straight') {
+      this.steeringAngle = 0;
+      return;
+    }
     const key = this.actionMap[action];
     if (key) this.keys[key] = true;
   }
@@ -434,25 +463,25 @@ export class Car {
             ? this.decelRate
             : 0;
 
-    if (this.keys.ArrowLeft) this.angularAcceleration = -this.rotAccelRate;
-    else if (this.keys.ArrowRight) this.angularAcceleration = this.rotAccelRate;
-    else
-      this.angularAcceleration =
-        this.angularVelocity > 0
-          ? -this.rotDecelRate
-          : this.angularVelocity < 0
-            ? this.rotDecelRate
-            : 0;
+    if (this.keys.ArrowLeft)
+      this.steeringAngle = Math.max(
+        -this.maxSteering,
+        this.steeringAngle - this.steerRate,
+      );
+    else if (this.keys.ArrowRight)
+      this.steeringAngle = Math.min(
+        this.maxSteering,
+        this.steeringAngle + this.steerRate,
+      );
+    else if (this.steeringAngle > 0)
+      this.steeringAngle = Math.max(0, this.steeringAngle - this.steerRate);
+    else if (this.steeringAngle < 0)
+      this.steeringAngle = Math.min(0, this.steeringAngle + this.steerRate);
 
     this.velocity += this.acceleration;
-    this.angularVelocity += this.angularAcceleration;
     this.velocity = Math.max(
       -this.maxSpeed,
       Math.min(this.maxSpeed, this.velocity),
-    );
-    this.angularVelocity = Math.max(
-      -0.03,
-      Math.min(0.03, this.angularVelocity),
     );
 
     if (
@@ -461,18 +490,18 @@ export class Car {
       !this.keys.ArrowDown
     )
       this.velocity = 0;
-    if (
-      Math.abs(this.angularVelocity) < 0.001 &&
-      !this.keys.ArrowLeft &&
-      !this.keys.ArrowRight
-    )
-      this.angularVelocity = 0;
+
+    const rotChange =
+      this.velocity !== 0
+        ? (this.velocity / this.wheelBase) * Math.tan(this.steeringAngle)
+        : 0;
+    this.angularVelocity = rotChange;
 
     // Move in the direction the car's front is facing.
     const frontRot = this.rotation + Math.PI;
     const nx = this.posX + Math.cos(frontRot) * this.velocity;
     const ny = this.posY + Math.sin(frontRot) * this.velocity;
-    const newRotation = this.rotation + this.angularVelocity;
+    const newRotation = this.rotation + rotChange;
     const bbox = this.getBoundingBox(nx, ny, newRotation);
 
     const inBounds =
@@ -490,18 +519,10 @@ export class Car {
         this.posY = ny;
         this.rotation = newRotation;
       } else {
-        this.velocity =
-          this.acceleration =
-          this.angularVelocity =
-          this.angularAcceleration =
-            0;
+        this.velocity = this.acceleration = 0;
       }
     } else {
-      this.velocity =
-        this.acceleration =
-        this.angularVelocity =
-        this.angularAcceleration =
-          0;
+      this.velocity = this.acceleration = 0;
     }
 
     this.speed = Math.abs(this.velocity * 60);

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -236,9 +236,13 @@ async function executeSteps(steps) {
     if (step.action) {
       const reps = step.repeat || 1;
       for (let i = 0; i < reps; i++) {
-        await sendAction(car, step.action);
-        await sleep(step.duration * 1000);
-        await sendAction(car, 'stop');
+        if (step.action === 'left' || step.action === 'right') {
+          await sendAction(car, step.action, step.duration);
+        } else {
+          await sendAction(car, step.action);
+          await sleep(step.duration * 1000);
+          await sendAction(car, 'stop');
+        }
       }
     } else if (step.condition || step.if) {
       const cond = step.condition || step.if;

--- a/test/autopilot.test.js
+++ b/test/autopilot.test.js
@@ -5,14 +5,16 @@ import { sendAction } from '../static/src/autopilot/send.js';
 test('sendAction sets keys and returns promise', async () => {
   const car = {
     keys: { ArrowUp: false, ArrowDown: false, ArrowLeft: false, ArrowRight: false },
-    setKeysFromAction(action) {
+    steeringAngle: 0,
+    setKeysFromAction(action, value) {
       for (const k in this.keys) this.keys[k] = false;
       if (action === 'forward') this.keys.ArrowUp = true;
+      if (action === 'left' && typeof value === 'number') this.steeringAngle = -value;
     },
   };
   global.fetch = async () => ({ ok: true });
-  const p = sendAction(car, 'forward');
+  const p = sendAction(car, 'left', 30);
   assert.ok(p instanceof Promise);
   await p;
-  assert.equal(car.keys.ArrowUp, true);
+  assert.equal(car.steeringAngle, -30);
 });


### PR DESCRIPTION
## Summary
- add steeringAngle properties to Car and limit steering to ±70°
- adapt car update loop to move based on steering angle
- extend sendAction to support a numeric value
- drive sequences with left/right angles
- test steering angle support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68755b13c2d883318b4e1b6b92faf985