### PR TITLE
Add map boundaries to car collision detection

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -329,7 +329,12 @@ export class Car {
       if (o.radius != null) {
         res = this.rayCircleIntersectionDetail(fx, fy, angle, o);
       } else {
-        const rect = { x: o.x, y: o.y, w: o.size, h: o.size };
+        const rect = {
+          x: o.x,
+          y: o.y,
+          w: o.w != null ? o.w : o.size,
+          h: o.h != null ? o.h : o.size,
+        };
         res = this.rayRectIntersectionDetail(fx, fy, angle, rect);
       }
       if (res.dist < minDist) {

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -384,6 +384,35 @@ function refreshCarObjects() {
   // Only obstacles should block the car. The target is handled
   // separately so the car can pass through it.
   car.objects = obstacles.slice();
+
+  // Add map boundaries so the car's sensors and collision
+  // detection account for the outer margin. Boundaries are
+  // represented as simple rectangles with an intersectsRect
+  // method so they behave like normal obstacles.
+  const width = gameMap.cols * gameMap.cellSize;
+  const height = gameMap.rows * gameMap.cellSize;
+  const m = gameMap.margin;
+  if (m > 0) {
+    const bounds = [
+      { x: 0, y: 0, w: width, h: m },
+      { x: 0, y: height - m, w: width, h: m },
+      { x: 0, y: 0, w: m, h: height },
+      { x: width - m, y: 0, w: m, h: height },
+    ];
+    for (const b of bounds) {
+      car.objects.push({
+        ...b,
+        intersectsRect(x, y, w, h) {
+          return !(
+            x + w < this.x ||
+            x > this.x + this.w ||
+            y + h < this.y ||
+            y > this.y + this.h
+          );
+        },
+      });
+    }
+  }
 }
 
 function respawnTarget() {


### PR DESCRIPTION
## Summary
- include map borders when refreshing car objects
- allow `Car.castRayPath` to accept rectangular objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68755f5497ec8331951dde8d755a976f