### PR TITLE
Fix syntax error in car.js

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -98,7 +98,6 @@ export class Car {
     for (const k of Object.keys(this.keys)) this.keys[k] = false;
   }
 
-  setKeysFromAction(action) {
   setKeysFromAction(action, value = null) {
     for (const k of Object.keys(this.keys)) this.keys[k] = false;
     if (action === 'left') {


### PR DESCRIPTION
## Summary
- remove obsolete `setKeysFromAction(action)` line

## Testing
- `node --check static/src/car.js`
- `npm test`
- `python server.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68756316c3408331aea447e5453ed3c9