### PR TITLE
Add angleOverride to Car steering

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -82,6 +82,7 @@ export class Car {
     this.maxSteering = (70 * Math.PI) / 180;
     this.steerRate = 0.02;
     this.wheelBase = 50;
+    this.angleOverride = false;
   }
 
   reset() {
@@ -98,32 +99,36 @@ export class Car {
     for (const k of Object.keys(this.keys)) this.keys[k] = false;
   }
 
-  setKeysFromAction(action) {
   setKeysFromAction(action, value = null) {
     for (const k of Object.keys(this.keys)) this.keys[k] = false;
     if (action === 'left') {
       if (typeof value === 'number') {
+        this.angleOverride = true;
         this.steeringAngle = Math.max(
           -this.maxSteering,
           Math.min(this.maxSteering, (-value * Math.PI) / 180),
         );
       } else {
+        this.angleOverride = false;
         this.keys.ArrowLeft = true;
       }
       return;
     }
     if (action === 'right') {
       if (typeof value === 'number') {
+        this.angleOverride = true;
         this.steeringAngle = Math.max(
           -this.maxSteering,
           Math.min(this.maxSteering, (value * Math.PI) / 180),
         );
       } else {
+        this.angleOverride = false;
         this.keys.ArrowRight = true;
       }
       return;
     }
     if (action === 'straight') {
+      this.angleOverride = false;
       this.steeringAngle = 0;
       return;
     }
@@ -495,10 +500,12 @@ export class Car {
         this.maxSteering,
         this.steeringAngle + this.steerRate,
       );
-    else if (this.steeringAngle > 0)
-      this.steeringAngle = Math.max(0, this.steeringAngle - this.steerRate);
-    else if (this.steeringAngle < 0)
-      this.steeringAngle = Math.min(0, this.steeringAngle + this.steerRate);
+    else if (!this.angleOverride) {
+      if (this.steeringAngle > 0)
+        this.steeringAngle = Math.max(0, this.steeringAngle - this.steerRate);
+      else if (this.steeringAngle < 0)
+        this.steeringAngle = Math.min(0, this.steeringAngle + this.steerRate);
+    }
 
     this.velocity += this.acceleration;
     this.velocity = Math.max(

--- a/test/car.test.js
+++ b/test/car.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Car } from '../static/src/car.js';
+
+global.window = { addEventListener() {} };
+
+test('angleOverride prevents auto-centering', () => {
+  const car = new Car({}, {}, 1, 10, []);
+  car.draw = () => {};
+  car.setKeysFromAction('right', 30);
+  const angle = car.steeringAngle;
+  car.update(800, 600);
+  assert.equal(car.angleOverride, true);
+  assert.equal(car.steeringAngle, angle);
+  car.setKeysFromAction('left');
+  assert.equal(car.angleOverride, false);
+});
+
+test('straight command resets angleOverride', () => {
+  const car = new Car({}, {}, 1, 10, []);
+  car.draw = () => {};
+  car.setKeysFromAction('left', 15);
+  assert.equal(car.angleOverride, true);
+  car.setKeysFromAction('straight');
+  assert.equal(car.angleOverride, false);
+  assert.equal(car.steeringAngle, 0);
+});


### PR DESCRIPTION
## Summary
- add `angleOverride` flag to car constructor
- reset and use `angleOverride` in `setKeysFromAction`
- skip auto‑centering while `angleOverride` is active
- test new steering override behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687562c3ce1c8331ae6ecc2638a4e5b5