### PR TITLE
Add next_map ability after 50% coverage

### DIFF
--- a/static/src/main.js
+++ b/static/src/main.js
@@ -159,7 +159,12 @@ async function pollControl() {
     const res = await fetch(CONTROL_API_URL);
     if (!res.ok) return;
     const data = await res.json();
-    if (data.action) car.setKeysFromAction(data.action);
+    if (!data.action) return;
+    if (data.action === 'next_map') {
+      loadMapByIndex(currentMapIndex + 1);
+    } else {
+      car.setKeysFromAction(data.action);
+    }
   } catch (err) {
     console.error('pollControl failed', err);
   }


### PR DESCRIPTION
## Summary
- give RL agent a new `next_map` action
- allow switching the map in `DummyEnv` and `ServerEnv`
- reward the agent when a map switch occurs
- handle `next_map` in the frontend control poller

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875829d5a648331b7db9edf73dce157