### PR TITLE
Implement map switch and stall restart

### DIFF
--- a/static/src/main.js
+++ b/static/src/main.js
@@ -162,6 +162,8 @@ async function pollControl() {
     if (!data.action) return;
     if (data.action === 'next_map') {
       loadMapByIndex(currentMapIndex + 1);
+    } else if (data.action === 'restart') {
+      resetMap();
     } else {
       car.setKeysFromAction(data.action);
     }


### PR DESCRIPTION
## Summary
- prevent premature map switching by verifying coverage in the agent
- detect when the car stalls for 10 seconds and restart the map with a penalty
- support `restart` control action on the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687585cdde308331b739c0c19b09b707