### PR TITLE
Add scoring and waypoint system

### DIFF
--- a/static/src/Waypoint.js
+++ b/static/src/Waypoint.js
@@ -1,0 +1,23 @@
+export class Waypoint {
+  constructor(x, y, size) {
+    this.x = x;
+    this.y = y;
+    this.size = size;
+    this.active = true;
+  }
+
+  draw(ctx) {
+    if (!this.active) return;
+    ctx.fillStyle = 'yellow';
+    ctx.fillRect(this.x, this.y, this.size, this.size);
+  }
+
+  intersectsRect(x, y, w, h) {
+    return !(
+      x + w < this.x ||
+      x > this.x + this.size ||
+      y + h < this.y ||
+      y > this.y + this.size
+    );
+  }
+}

--- a/static/src/car.js
+++ b/static/src/car.js
@@ -17,6 +17,7 @@ export class Car {
     this.scale = scale;
     this.margin = margin;
     this.objects = objects;
+    this.crashed = false;
 
     this.showHitbox = false;
 
@@ -104,6 +105,7 @@ export class Car {
     this.rpm = 0;
     this.gyro = 0;
     for (const k of Object.keys(this.keys)) this.keys[k] = false;
+    this.crashed = false;
   }
 
   setKeysFromAction(action, value = null) {
@@ -573,11 +575,14 @@ export class Car {
         this.posX = nx;
         this.posY = ny;
         this.rotation = newRotation;
+        this.crashed = false;
       } else {
         this.velocity = this.acceleration = 0;
+        this.crashed = true;
       }
     } else {
       this.velocity = this.acceleration = 0;
+      this.crashed = true;
     }
 
     this.speed = Math.abs(this.velocity * 60);

--- a/static/src/csvMap.js
+++ b/static/src/csvMap.js
@@ -1,6 +1,7 @@
 import { GameMap } from './map.js';
 import { Obstacle } from './Obstacle.js';
 import { Target } from './Target.js';
+import { Waypoint } from './Waypoint.js';
 
 export function parseCsvMap(text) {
   const lines = text.trim().split(/\r?\n/);
@@ -16,6 +17,14 @@ export function parseCsvMap(text) {
         parseFloat(parts[1]),
         parseFloat(parts[2]),
         parseFloat(parts[3]),
+      );
+    } else if (parts[0] === 'waypoint') {
+      gm.waypoints.push(
+        new Waypoint(
+          parseFloat(parts[1]),
+          parseFloat(parts[2]),
+          parseFloat(parts[3]),
+        ),
       );
     } else if (parts[0] === 'obstacle') {
       gm.obstacles.push(
@@ -43,6 +52,9 @@ export function serializeCsvMap(gameMap) {
         gameMap.target.radius,
       ].join(','),
     );
+  }
+  for (const w of gameMap.waypoints) {
+    lines.push(['waypoint', w.x, w.y, w.size].join(','));
   }
   for (const o of gameMap.obstacles) {
     lines.push(['obstacle', o.x, o.y, o.size].join(','));

--- a/static/src/db.js
+++ b/static/src/db.js
@@ -11,6 +11,7 @@ export function getCurrentMapData(gameMap) {
           size: gameMap.target.radius,
         }
       : null,
+    waypoints: gameMap.waypoints.map((w) => ({ x: w.x, y: w.y, size: w.size })),
   };
 }
 

--- a/static/src/map.js
+++ b/static/src/map.js
@@ -1,5 +1,6 @@
 import { Obstacle } from './Obstacle.js';
 import { Target } from './Target.js';
+import { Waypoint } from './Waypoint.js';
 
 export class GameMap {
   constructor(cols, rows, cellSize = 40, margin = 0) {
@@ -9,6 +10,7 @@ export class GameMap {
     this.margin = margin;
     this.obstacles = [];
     this.target = null;
+    this.waypoints = [];
   }
 
   get width() {
@@ -62,6 +64,7 @@ export class GameMap {
       target: this.target
         ? { x: this.target.x, y: this.target.y, size: this.target.radius }
         : null,
+      waypoints: this.waypoints.map((w) => ({ x: w.x, y: w.y, size: w.size })),
     };
   }
 
@@ -73,6 +76,9 @@ export class GameMap {
     gm.target = obj.target
       ? new Target(obj.target.x, obj.target.y, obj.target.size)
       : null;
+    if (obj.waypoints) {
+      gm.waypoints = obj.waypoints.map((w) => new Waypoint(w.x, w.y, w.size));
+    }
     return gm;
   }
 }

--- a/templates/map2.html
+++ b/templates/map2.html
@@ -67,6 +67,7 @@
   </head>
   <body>
     <div id="controls">
+      <div class="cone-display" id="scoreBoard">Punkte: <span id="score">0</span></div>
       <div id="editorTools">
         <div>
           <label>Typ:</label>
@@ -74,6 +75,7 @@
             <option value="obstacle">Quadrat</option>
             <option value="corner">Eckpunkt</option>
             <option value="target">Target (grüner Punkt)</option>
+            <option value="waypoint">Zwischenziel</option>
           </select>
           <label>Größe:</label>
           <input


### PR DESCRIPTION
## Summary
- introduce waypoint object and editing support
- extend maps and CSV handling for waypoints
- track score and display it in map2.html
- calculate points for SLAM coverage, waypoints, crashes and goal
- detect crashes via car.crashed flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876bf04d59083319f0dc7e2c6ff6f5e