### PR TITLE
Display car coordinates on status map

### DIFF
--- a/static/src/status.js
+++ b/static/src/status.js
@@ -26,6 +26,13 @@ function drawGrid() {
     ctx.beginPath();
     ctx.arc(lastPos.x, lastPos.y, 4, 0, 2 * Math.PI);
     ctx.fill();
+    // Display the coordinates in the top right corner
+    ctx.fillStyle = '#fff';
+    ctx.font = '12px Arial';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    const coordText = `(${Math.round(lastPos.x)}, ${Math.round(lastPos.y)})`;
+    ctx.fillText(coordText, canvas.width - 4, 4);
   }
 }
 


### PR DESCRIPTION
## Summary
- show car coordinate text at the top-right corner of the status map

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6876c0c51bcc8331a3507121ddbb9f49