### PR TITLE
Fix sensor reflection and SLAM hit persistence

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -360,26 +360,10 @@ export class Car {
 
     const segment = { x: fx, y: fy, angle, length: minDist };
 
-    if (!bestNormal || minDist >= length) return [segment];
-
-    const ix = fx + Math.cos(angle) * minDist;
-    const iy = fy + Math.sin(angle) * minDist;
-
-    const nAngle = Math.atan2(bestNormal[1], bestNormal[0]);
-    let tAngle1 = nAngle + Math.PI / 2;
-    let tAngle2 = nAngle - Math.PI / 2;
-    const diff1 = Math.abs(this.normAngle(tAngle1 - angle));
-    const diff2 = Math.abs(this.normAngle(tAngle2 - angle));
-    const newAngle = diff1 < diff2 ? tAngle1 : tAngle2;
-
-    const rest = this.castRayPath(
-      ix + Math.cos(newAngle) * 0.1,
-      iy + Math.sin(newAngle) * 0.1,
-      newAngle,
-      length - minDist,
-      depth + 1,
-    );
-    return [segment, ...rest];
+    // Only return the first segment up to the initial hit without
+    // following the wall. This prevents reflections or wall hugging
+    // behaviour for simulated sensors.
+    return [segment];
   }
 
   drawKegel(

--- a/static/src/main.js
+++ b/static/src/main.js
@@ -35,6 +35,8 @@ const slamCanvas = document.getElementById('slamCanvas');
 const slamCtx = slamCanvas.getContext('2d');
 let slamMode = false;
 let prevCarRect = null;
+// Store all hit locations so repeated scans do not remove markers
+const slamHits = [];
 const saveMapCsvBtn = document.getElementById('saveMapCsv');
 const overwriteCsvBtn = document.getElementById('overwriteMapCsv');
 const connectCornersBtn = document.getElementById('connectCorners');
@@ -122,6 +124,7 @@ if (slamCheckbox) {
       slamCtx.fillStyle = 'rgba(128,128,128,0.5)';
       slamCtx.fillRect(0, 0, slamCanvas.width, slamCanvas.height);
       prevCarRect = null;
+      slamHits.length = 0;
       revealCar();
       if (coverageInterval) clearInterval(coverageInterval);
       coverageInterval = setInterval(updateSlamCoverage, 1000);
@@ -132,6 +135,7 @@ if (slamCheckbox) {
       slamCanvas.style.display = 'none';
       slamCtx.clearRect(0, 0, slamCanvas.width, slamCanvas.height);
       prevCarRect = null;
+      slamHits.length = 0;
       if (coverageInterval) clearInterval(coverageInterval);
       if (slamCoverageEl) slamCoverageEl.textContent = '0%';
       coverageScore = 0;
@@ -504,6 +508,7 @@ function resizeCanvas() {
     slamCtx.fillStyle = 'rgba(128,128,128,0.5)';
     slamCtx.fillRect(0, 0, slamCanvas.width, slamCanvas.height);
     prevCarRect = null;
+    slamHits.length = 0;
     revealCar();
     updateSlamCoverage();
   }
@@ -598,12 +603,19 @@ function revealCone(x, y, length, angle, baseWidth) {
     (hx, hy) => (hit = { x: hx, y: hy }),
   );
   slamCtx.restore();
-  if (hit) {
-    slamCtx.fillStyle = 'red';
+  if (hit) slamHits.push(hit);
+  drawSlamHits();
+}
+
+function drawSlamHits() {
+  slamCtx.save();
+  slamCtx.fillStyle = 'red';
+  for (const p of slamHits) {
     slamCtx.beginPath();
-    slamCtx.arc(hit.x, hit.y, 3, 0, 2 * Math.PI);
+    slamCtx.arc(p.x, p.y, 3, 0, 2 * Math.PI);
     slamCtx.fill();
   }
+  slamCtx.restore();
 }
 
 function revealCar() {
@@ -619,6 +631,7 @@ function revealCar() {
   slamCtx.fillRect(bbox.x, bbox.y, bbox.w, bbox.h);
   slamCtx.restore();
   prevCarRect = bbox;
+  drawSlamHits();
 }
 
 function updateSlamCoverage() {
@@ -996,6 +1009,7 @@ function loadMapByIndex(idx) {
       slamCtx.fillStyle = 'rgba(128,128,128,0.5)';
       slamCtx.fillRect(0, 0, slamCanvas.width, slamCanvas.height);
       prevCarRect = null;
+      slamHits.length = 0;
       revealCar();
       updateSlamCoverage();
     }
@@ -1021,6 +1035,7 @@ function resetMap() {
     slamCtx.fillStyle = 'rgba(128,128,128,0.5)';
     slamCtx.fillRect(0, 0, slamCanvas.width, slamCanvas.height);
     prevCarRect = null;
+    slamHits.length = 0;
     revealCar();
     updateSlamCoverage();
   }


### PR DESCRIPTION
## Summary
- remove wall-following logic from sensor ray casting
- retain sensor hit markers on the SLAM map even when re-scanned
- preserve hit markers when toggling or resetting SLAM mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c5d91ab883319da26ff3bde32c75