### PR TITLE
Allow steering keys to move car forward

### DIFF
--- a/static/src/car.js
+++ b/static/src/car.js
@@ -87,7 +87,7 @@ export class Car {
 
     // Steering state in radians
     this.steeringAngle = 0;
-    this.maxSteering = (70 * Math.PI) / 180;
+    this.maxSteering = (60 * Math.PI) / 180;
     // Reduced steering sensitivity
     this.steerRate = 0.015;
     this.wheelBase = 50;
@@ -494,7 +494,9 @@ export class Car {
       this.acceleration = 0;
       this.velocity = this.fixedSpeed / 60;
     } else {
-      if (this.keys.ArrowUp) this.acceleration = this.accelRate;
+      const steeringOnly =
+        (this.keys.ArrowLeft || this.keys.ArrowRight) && !this.keys.ArrowDown;
+      if (this.keys.ArrowUp || steeringOnly) this.acceleration = this.accelRate;
       else if (this.keys.ArrowDown) this.acceleration = -this.accelRate;
       else
         this.acceleration =

--- a/test/car.test.js
+++ b/test/car.test.js
@@ -25,3 +25,11 @@ test('straight command resets angleOverride', () => {
   assert.equal(car.angleOverride, false);
   assert.equal(car.steeringAngle, 0);
 });
+
+test('pressing left or right moves forward', () => {
+  const car = new Car({}, {}, 1, 10, []);
+  car.draw = () => {};
+  car.keys.ArrowLeft = true;
+  car.update(800, 600);
+  assert.equal(car.velocity, car.accelRate);
+});


### PR DESCRIPTION
## Summary
- limit steering range to 60°
- start moving forward when only left/right key is pressed
- test that steering alone accelerates the car

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c6a867d08331be643d394e7699bb