### PR TITLE
Move API code from main to dedicated module

### DIFF
--- a/VE/static/src/api/config.js
+++ b/VE/static/src/api/config.js
@@ -2,3 +2,5 @@
 // without any additional configuration.
 export const CONTROL_API_URL = '/api/control';
 export const TELEMETRY_API_URL = '/api/car';
+export const MAPS_API_URL = '/api/maps';
+export const CSV_MAPS_API_URL = '/api/csv-maps';

--- a/VE/static/src/api/maps.js
+++ b/VE/static/src/api/maps.js
@@ -1,0 +1,24 @@
+import { MAPS_API_URL, CSV_MAPS_API_URL } from './config.js';
+
+export function pushMap(gameMap, name = 'map') {
+  const data = gameMap.toJSON ? gameMap.toJSON() : gameMap;
+  return fetch(MAPS_API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, map: data }),
+  });
+}
+
+export async function fetchCsvMapList() {
+  const res = await fetch(CSV_MAPS_API_URL);
+  if (!res.ok) throw new Error('Failed to load map list');
+  return res.json();
+}
+
+export function overwriteCsvMap(file, csv) {
+  return fetch(`${CSV_MAPS_API_URL}/${encodeURIComponent(file)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ csv }),
+  });
+}


### PR DESCRIPTION
## Summary
- centralize API URLs in `config.js`
- add new API helpers in `maps.js`
- use the new helpers inside `main.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876d7f951488331a0065696578a75a2