### PR TITLE
Fix map switching on target collision

### DIFF
--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -718,7 +718,6 @@ function loop() {
       updateScoreBoard();
       targetMarker = null;
       nextMap();
-      return;
     }
   }
   for (const wp of waypoints) {


### PR DESCRIPTION
## Summary
- allow the animation loop to continue after hitting the target

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e91935948331be5a87abeeeb5ed2