### PR TITLE
Enable saving and loading DQN model

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,10 @@ possible to edit and extend previously created command sequences.
 Sequences saved as CSV or ROS files can also be loaded. When imported, they are
 converted into simple action lists so they can be further adjusted and saved
 again, e.g. in JSON format for advanced features.
+
+## Reinforcement Learning
+
+The script `RL/train.py` trains a simple DQN agent that interacts with the
+server via the REST API. The model weights are stored in `RL/dqn_model.h5` after
+each episode so training can resume from the last run. When `train.py` is
+executed again the agent automatically loads this file if it exists.

--- a/RL/Agent.py
+++ b/RL/Agent.py
@@ -2,16 +2,23 @@ import numpy as np
 import random
 from collections import deque
 import tensorflow as tf
+import os
 from utils import STATE_SIZE, ACTION_SIZE
 
 class DQNAgent:
-    def __init__(self):
+    def __init__(self, weights_path="dqn_model.h5"):
         self.memory = deque(maxlen=2000)
+        self.weights_path = weights_path
         self.gamma = 0.95
         self.epsilon = 1.0
         self.epsilon_min = 0.01
         self.epsilon_decay = 0.995
         self.model = self._build_model()
+        if os.path.exists(self.weights_path):
+            try:
+                self.model = tf.keras.models.load_model(self.weights_path)
+            except Exception:
+                self.model.load_weights(self.weights_path)
 
     def _build_model(self):
         m = tf.keras.models.Sequential([
@@ -40,3 +47,6 @@ class DQNAgent:
             self.model.fit(s[np.newaxis], q, epochs=1, verbose=0)
         if self.epsilon > self.epsilon_min:
             self.epsilon *= self.epsilon_decay
+
+    def save(self):
+        self.model.save(self.weights_path)

--- a/RL/train.py
+++ b/RL/train.py
@@ -7,7 +7,7 @@ from utils import ACTIONS
 
 if __name__ == '__main__':
     env = ServerEnv(BASE_URL)
-    agent = DQNAgent()
+    agent = DQNAgent("dqn_model.h5")
     logger = Logger("rl_log.csv")
     for ep in range(NUM_EPISODES):
         state = env.reset()
@@ -25,4 +25,5 @@ if __name__ == '__main__':
             if done:
                 break
         agent.replay()
+        agent.save()
     logger.close()


### PR DESCRIPTION
## Summary
- let `DQNAgent` optionally load an existing model file
- add method to persist model weights
- store model after each training episode
- document RL training model persistence

## Testing
- `python -m py_compile RL/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6876ebf6a5508331b94f641de4e43070