### PR TITLE
Fix map list loading for next map

### DIFF
--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -111,6 +111,9 @@ async function initMapList() {
   }
 }
 
+// Immediately start loading the list of available maps.
+const mapListReady = initMapList();
+
 
 
 window.addEventListener('keydown', (e) => {
@@ -913,7 +916,9 @@ function autoFollowCar(margin = 50) {
 findCarBtn.addEventListener('click', () => centerOnCar(500));
 if (restartBtn) restartBtn.addEventListener('click', resetMap);
 function nextMap() {
-  ensureMapList().then(() => loadMapByIndex(currentMapIndex + 1));
+  ensureMapList(mapList, mapListReady).then(() =>
+    loadMapByIndex(currentMapIndex + 1),
+  );
 }
 
 if (nextMapBtn) nextMapBtn.addEventListener('click', nextMap);


### PR DESCRIPTION
## Summary
- ensure map list is loaded at startup
- pass loaded list to `ensureMapList` when switching to the next map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68777fab13b88331bb296395eb1ccbfa