### PR TITLE
Enlarge target hitbox

### DIFF
--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -23,7 +23,7 @@ function pushMapToServer(gameMap, name = 'map') {
 // 1 Pixel entspricht dieser Anzahl Zentimeter
 const CM_PER_PX = 2;
 const WAYPOINT_SIZE = 20 / CM_PER_PX;
-const TARGET_SIZE = 20;
+const TARGET_SIZE = WAYPOINT_SIZE;
 
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
@@ -261,7 +261,7 @@ function refreshCarObjects() {
 }
 
 function respawnTarget() {
-  const size = targetMarker ? targetMarker.size : TARGET_SIZE;
+  const size = TARGET_SIZE;
   for (let i = 0; i < 100; i++) {
     const col = Math.floor(Math.random() * gameMap.cols);
     const row = Math.floor(Math.random() * gameMap.rows);
@@ -312,11 +312,9 @@ function updateObstacleOptions() {
   const size = parseInt(sizeInput.value);
   sizeInput.value = isNaN(size) ? 1 : Math.max(1, Math.min(25, size));
   previewSize =
-    typeSelect.value === 'target'
-      ? CELL_SIZE
-      : typeSelect.value === 'waypoint'
-        ? WAYPOINT_SIZE
-        : parseInt(sizeInput.value) * CELL_SIZE;
+    typeSelect.value === 'target' || typeSelect.value === 'waypoint'
+      ? WAYPOINT_SIZE
+      : parseInt(sizeInput.value) * CELL_SIZE;
 }
 
 function resizeCanvas() {

--- a/VE/static/src/map/csvMap.js
+++ b/VE/static/src/map/csvMap.js
@@ -3,6 +3,8 @@ import { Obstacle } from './Obstacle.js';
 import { Target } from './Target.js';
 import { Waypoint } from './Waypoint.js';
 
+const TARGET_SIZE = 10; // same size as waypoint
+
 export function parseCsvMap(text) {
   const lines = text.trim().split(/\r?\n/);
   if (!lines.length) return new GameMap(20, 15);
@@ -16,7 +18,7 @@ export function parseCsvMap(text) {
       gm.target = new Target(
         parseFloat(parts[1]),
         parseFloat(parts[2]),
-        parseFloat(parts[3]),
+        TARGET_SIZE,
       );
     } else if (parts[0] === 'waypoint') {
       gm.waypoints.push(

--- a/VE/static/src/map/map.js
+++ b/VE/static/src/map/map.js
@@ -2,6 +2,8 @@ import { Obstacle } from './Obstacle.js';
 import { Target } from './Target.js';
 import { Waypoint } from './Waypoint.js';
 
+const TARGET_SIZE = 10; // match waypoint size
+
 export class GameMap {
   constructor(cols, rows, cellSize = 40, margin = 0) {
     this.cols = cols;
@@ -74,7 +76,7 @@ export class GameMap {
       gm.obstacles = obj.obstacles.map((o) => new Obstacle(o.x, o.y, o.size));
     }
     gm.target = obj.target
-      ? new Target(obj.target.x, obj.target.y, obj.target.size)
+      ? new Target(obj.target.x, obj.target.y, TARGET_SIZE)
       : null;
     if (obj.waypoints) {
       gm.waypoints = obj.waypoints.map((w) => new Waypoint(w.x, w.y, w.size));


### PR DESCRIPTION
## Summary
- make targets the same size as waypoints
- adjust preview logic when editing
- always spawn new targets with the larger hitbox
- ensure loaded maps use the new target size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687781531484833188acdf97b89fb346