### PR TITLE
Add map creation tile and drag reorder

### DIFF
--- a/VE/server.py
+++ b/VE/server.py
@@ -307,6 +307,22 @@ def update_csv_map(filename):
     return '', 204
 
 
+@app.route('/api/csv-maps/order', methods=['PUT'])
+def reorder_csv_maps():
+    data = request.get_json(force=True)
+    order = data.get('order')
+    if not isinstance(order, list):
+        return jsonify({'error': 'invalid order'}), 400
+    maps_list = load_csv_map_list()
+    file_to_entry = {m['file']: m for m in maps_list}
+    new_list = [file_to_entry[f] for f in order if f in file_to_entry]
+    for m in maps_list:
+        if m['file'] not in order:
+            new_list.append(m)
+    save_csv_map_list(new_list)
+    return '', 204
+
+
 @app.route('/api/maps', methods=['GET', 'POST'])
 def maps_route():
     if request.method == 'POST':

--- a/VE/static/src/map/index.js
+++ b/VE/static/src/map/index.js
@@ -1,58 +1,105 @@
 import { parseCsvMap } from './csvMap.js';
 
+let dragged = null;
+
+function makeTile(m, grid) {
+  const tile = document.createElement('div');
+  tile.className = 'tile';
+  tile.draggable = true;
+  tile.dataset.file = m.file;
+  tile.innerHTML = `
+    <canvas width="160" height="120"></canvas>
+    <div class="name">${m.name}</div>
+    <div class="meta">${new Date(m.created).toLocaleDateString()} - ${m.creator}</div>
+    <div class="buttons">
+      <button class="play">Spielen</button>
+      <button class="edit">Bearbeiten</button>
+      <button class="rename">Umbenennen</button>
+      <button class="delete">Löschen</button>
+    </div>`;
+  const canvas = tile.querySelector('canvas');
+  const ctx = canvas.getContext('2d');
+  fetch('/static/maps/' + m.file)
+    .then((r) => r.text())
+    .then((text) => {
+      const gm = parseCsvMap(text);
+      gm.drawGrid(ctx);
+      gm.obstacles.forEach((o) => o.draw(ctx));
+      if (gm.target) gm.target.draw(ctx);
+    });
+  tile.querySelector('.play').addEventListener('click', () => {
+    window.location.href =
+      '/map2?map=/static/maps/' + encodeURIComponent(m.file);
+  });
+  tile.querySelector('.edit').addEventListener('click', () => {
+    window.location.href =
+      '/map2?map=/static/maps/' + encodeURIComponent(m.file) + '&editor=1';
+  });
+  tile.querySelector('.rename').addEventListener('click', async () => {
+    const newName = prompt('Neuer Name:', m.name);
+    if (!newName) return;
+    await fetch('/api/csv-maps/' + encodeURIComponent(m.file), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName }),
+    });
+    loadList();
+  });
+  tile.querySelector('.delete').addEventListener('click', async () => {
+    if (!confirm('Diese Karte wirklich löschen?')) return;
+    await fetch('/api/csv-maps/' + encodeURIComponent(m.file), {
+      method: 'DELETE',
+    });
+    loadList();
+  });
+
+  tile.addEventListener('dragstart', () => {
+    dragged = tile;
+  });
+  tile.addEventListener('dragend', () => {
+    dragged = null;
+  });
+  tile.addEventListener('dragover', (e) => {
+    e.preventDefault();
+  });
+  tile.addEventListener('drop', (e) => {
+    e.preventDefault();
+    if (!dragged || dragged === tile) return;
+    const rect = tile.getBoundingClientRect();
+    const after = e.clientY > rect.top + rect.height / 2;
+    grid.insertBefore(dragged, after ? tile.nextSibling : tile);
+    updateOrder(grid);
+  });
+  return tile;
+}
+
+function updateOrder(grid) {
+  const order = Array.from(grid.children)
+    .filter((t) => t.dataset.file)
+    .map((t) => t.dataset.file);
+  fetch('/api/csv-maps/order', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ order }),
+  }).catch((err) => console.error('reorder failed', err));
+}
+
 async function loadList() {
   const res = await fetch('/api/csv-maps');
   const maps = await res.json();
   const grid = document.getElementById('mapGrid');
   grid.innerHTML = '';
   for (const m of maps) {
-    const tile = document.createElement('div');
-    tile.className = 'tile';
-    tile.innerHTML = `
-      <canvas width="160" height="120"></canvas>
-      <div class="name">${m.name}</div>
-      <div class="meta">${new Date(m.created).toLocaleDateString()} - ${m.creator}</div>
-      <div class="buttons">
-        <button class="play">Spielen</button>
-        <button class="edit">Bearbeiten</button>
-        <button class="rename">Umbenennen</button>
-        <button class="delete">Löschen</button>
-      </div>`;
+    const tile = makeTile(m, grid);
     grid.appendChild(tile);
-    const canvas = tile.querySelector('canvas');
-    const ctx = canvas.getContext('2d');
-    const mapRes = await fetch('/static/maps/' + m.file);
-    const text = await mapRes.text();
-    const gm = parseCsvMap(text);
-    gm.drawGrid(ctx);
-    gm.obstacles.forEach((o) => o.draw(ctx));
-    if (gm.target) gm.target.draw(ctx);
-    tile.querySelector('.play').addEventListener('click', () => {
-      window.location.href =
-        '/map2?map=/static/maps/' + encodeURIComponent(m.file);
-    });
-    tile.querySelector('.edit').addEventListener('click', () => {
-      window.location.href =
-        '/map2?map=/static/maps/' + encodeURIComponent(m.file) + '&editor=1';
-    });
-    tile.querySelector('.rename').addEventListener('click', async () => {
-      const newName = prompt('Neuer Name:', m.name);
-      if (!newName) return;
-      await fetch('/api/csv-maps/' + encodeURIComponent(m.file), {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newName }),
-      });
-      loadList();
-    });
-    tile.querySelector('.delete').addEventListener('click', async () => {
-      if (!confirm('Diese Karte wirklich löschen?')) return;
-      await fetch('/api/csv-maps/' + encodeURIComponent(m.file), {
-        method: 'DELETE',
-      });
-      loadList();
-    });
   }
+  const add = document.createElement('div');
+  add.className = 'tile add-tile';
+  add.innerHTML = '<div class="plus">+</div><div>Neue Karte</div>';
+  add.addEventListener('click', () => {
+    window.location.href = '/map2?editor=1';
+  });
+  grid.appendChild(add);
 }
 
 loadList();

--- a/VE/templates/index.html
+++ b/VE/templates/index.html
@@ -22,9 +22,19 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      cursor: grab;
     }
     .tile canvas {
       background: #fff;
+    }
+    .add-tile {
+      justify-content: center;
+      font-size: 64px;
+      color: #888;
+      cursor: pointer;
+    }
+    .add-tile .plus {
+      pointer-events: none;
     }
     .buttons {
       display: flex;


### PR DESCRIPTION
## Summary
- add UI for creating new empty map with a `+` tile
- enable drag-and-drop map reordering and store order server-side
- expose new `/api/csv-maps/order` endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68778a91709c833197b6a2cb588bc907