### PR TITLE
Add waypoint reward support

### DIFF
--- a/VE/server.py
+++ b/VE/server.py
@@ -19,6 +19,7 @@ current_map = None
 current_grid = None
 current_slam_map = None
 goal_reached = False
+waypoint_reached = False
 
 
 @app.route('/')
@@ -398,6 +399,18 @@ def goal():
         return '', 204
     reached = goal_reached
     goal_reached = False
+    return jsonify({'reached': reached})
+
+
+@app.route('/api/waypoint', methods=['GET', 'POST'])
+def waypoint():
+    """Flag indicating that a waypoint was reached."""
+    global waypoint_reached
+    if request.method == 'POST':
+        waypoint_reached = True
+        return '', 204
+    reached = waypoint_reached
+    waypoint_reached = False
     return jsonify({'reached': reached})
 
 

--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -639,6 +639,9 @@ function loop() {
       wp.active = false;
       score += 10;
       updateScoreBoard();
+      fetch('/api/waypoint', { method: 'POST' }).catch((err) =>
+        console.error('waypoint notify failed', err),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- reward RL agent for intermediate goals
- add `/api/waypoint` endpoint on server
- notify server when waypoints are reached

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --prefix VE`

------
https://chatgpt.com/codex/tasks/task_e_68778b35df788331972d32d8c24e8982