### PR TITLE
Add second rotatable camera cone

### DIFF
--- a/VE/static/src/car/car.js
+++ b/VE/static/src/car/car.js
@@ -92,6 +92,10 @@ export class Car {
     this.steerRate = 0.015;
     this.wheelBase = 50;
     this.angleOverride = false;
+
+    // Second camera cone angle in radians
+    this.camera2Angle = 0;
+    this.greenCone2Length = 0;
   }
 
   reset() {
@@ -140,6 +144,13 @@ export class Car {
     if (action === 'straight') {
       this.angleOverride = false;
       this.steeringAngle = 0;
+      return;
+    }
+    if (action === 'camera2') {
+      if (typeof value === 'number') {
+        const deg = Math.max(-90, Math.min(90, value));
+        this.camera2Angle = (deg * Math.PI) / 180;
+      }
       return;
     }
     const key = this.actionMap[action];
@@ -445,6 +456,14 @@ export class Car {
 
     this.redConeLength = this.drawKegel(18, 40, 700, Math.PI, 'red', 6);
     this.greenConeLength = this.drawKegel(45, 40, 400, Math.PI, 'green', 140);
+    this.greenCone2Length = this.drawKegel(
+      45,
+      40,
+      400,
+      Math.PI + this.camera2Angle,
+      'green',
+      140,
+    );
     const bluePoints = [
       [65, 7],
       [72, 7],

--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -60,6 +60,9 @@ const keyMap = {
 };
 const redEl = document.getElementById('redLength');
 const greenEl = document.getElementById('greenLength');
+const green2El = document.getElementById('green2Length');
+const cam2Slider = document.getElementById('camera2Angle');
+const cam2SliderVal = document.getElementById('camera2AngleVal');
 const blueLeft1El = document.getElementById('blueLeft1');
 const blueLeft2El = document.getElementById('blueLeft2');
 const blueRight1El = document.getElementById('blueRight1');
@@ -648,6 +651,9 @@ function loop() {
 
   redEl.textContent = Math.round(car.redConeLength);
   greenEl.textContent = Math.round(car.greenConeLength);
+  const g2 = car.drawKegel(45, 40, 400, Math.PI + car.camera2Angle, 'green', 140);
+  car.greenCone2Length = g2;
+  if (green2El) green2El.textContent = Math.round(g2);
   const bl1 = car.drawKegel(65, 7, 150, -Math.PI / 2, 'blue', 8);
   const bl2 = car.drawKegel(72, 7, 150, -Math.PI / 2, 'blue', 8);
   const br1 = car.drawKegel(91, 7, 150, -Math.PI / 2, 'blue', 8);
@@ -657,6 +663,7 @@ function loop() {
     revealCar();
     revealCone(18, 40, 700, Math.PI, 6);
     revealCone(45, 40, 400, Math.PI, 140);
+    revealCone(45, 40, 400, Math.PI + car.camera2Angle, 140);
     for (const [x, y] of [
       [65, 7],
       [72, 7],
@@ -961,5 +968,12 @@ if (speedSlider) {
     const val = parseFloat(speedSlider.value);
     if (speedSliderVal) speedSliderVal.textContent = val;
     car.fixedSpeed = val > 0 ? val : null;
+  });
+}
+if (cam2Slider) {
+  cam2Slider.addEventListener('input', () => {
+    const val = parseFloat(cam2Slider.value);
+    if (cam2SliderVal) cam2SliderVal.textContent = val;
+    car.camera2Angle = (val * Math.PI) / 180;
   });
 }

--- a/VE/templates/map2.html
+++ b/VE/templates/map2.html
@@ -98,6 +98,7 @@
       </button>
       <div class="cone-display">LiDAR vorne (rot): <span id="redLength">0</span> px</div>
       <div class="cone-display">Kamera (grün): <span id="greenLength">0</span> px</div>
+      <div class="cone-display">Kamera 2 (grün): <span id="green2Length">0</span> px</div>
       <div class="cone-display">
         Sonar links 1 (blau): <span id="blueLeft1">0</span> px
       </div>
@@ -123,6 +124,11 @@
       </div>
       <div class="cone-display">Drehzahl: <span id="rpm">0</span> RPM</div>
       <div class="cone-display">Gyro: <span id="gyro">0</span>°</div>
+      <div class="cone-display" id="cam2AngleControl">
+        <label for="camera2Angle">Kamera 2 Winkel:</label>
+        <input type="range" id="camera2Angle" min="-90" max="90" value="0" />
+        <span id="camera2AngleVal">0</span>°
+      </div>
       <div class="cone-display">Abdeckung: <span id="slamCoverage">0%</span></div>
       <div id="editorTools2">
         <label


### PR DESCRIPTION
## Summary
- add new display and control elements for an additional camera cone
- allow setting `camera2` angle via API
- draw second camera cone in car logic
- compute and show second camera distance in the main loop

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68778e51bdd08331ab67ce604cbed28f