### PR TITLE
Enable camera control for RL

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -108,8 +108,15 @@ class ServerEnv:
         self.map_switched = False
         self.waypoint_hit = False
         action = ACTIONS[idx]
+        payload = {"action": action}
+        if action == "cam_left":
+            payload = {"action": "camera2", "value": -45}
+        elif action == "cam_center":
+            payload = {"action": "camera2", "value": 0}
+        elif action == "cam_right":
+            payload = {"action": "camera2", "value": 45}
         try:
-            requests.post(f"{self.base_url}/api/control", json={"action": action}, timeout=5)
+            requests.post(f"{self.base_url}/api/control", json=payload, timeout=5)
         except Exception:
             pass
         self.done = False

--- a/RL/utils.py
+++ b/RL/utils.py
@@ -1,3 +1,15 @@
-ACTIONS = ["forward", "left", "right", "backward", "stop"]
+# Available actions for the RL agent. Besides the basic driving commands
+# three additional entries allow controlling the second camera. The camera
+# can be pointed 45 degrees to the left or right or straight ahead.
+ACTIONS = [
+    "forward",
+    "left",
+    "right",
+    "backward",
+    "stop",
+    "cam_left",
+    "cam_center",
+    "cam_right",
+]
 STATE_SIZE = 7
 ACTION_SIZE = len(ACTIONS)

--- a/VE/static/src/api/telemetry.js
+++ b/VE/static/src/api/telemetry.js
@@ -5,7 +5,7 @@ export async function pollControl(car) {
     const res = await fetch(CONTROL_API_URL);
     if (!res.ok) return;
     const data = await res.json();
-    if (data.action) car.setKeysFromAction(data.action);
+    if (data.action) car.setKeysFromAction(data.action, data.value);
   } catch (err) {
     console.error('pollControl failed', err);
   }


### PR DESCRIPTION
## Summary
- add discrete camera control actions for the RL agent
- translate those actions to `/api/control` requests
- pass value information through the telemetry polling on the web page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68779020064c8331b77b2717d38f32f9