### PR TITLE
Handle obstacles in coverage

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -77,8 +77,9 @@ class ServerEnv:
         try:
             slam_res = requests.get(f"{self.base_url}/api/slam-map", timeout=5)
             cells = slam_res.json().get("cells", [])
-            total = sum(len(row) for row in cells)
-            known = sum(1 for row in cells for val in row if val != 0)
+            non_obstacle = [val for row in cells for val in row if val != 2]
+            total = len(non_obstacle)
+            known = sum(1 for val in non_obstacle if val != 0)
             coverage = known / total if total else 0.0
         except Exception:
             coverage = 0.0

--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -408,11 +408,17 @@ function updateSlamCoverage() {
     slamCanvas.height,
   ).data;
   let cleared = 0;
-  for (let i = 3; i < data.length; i += 4) {
-    if (data[i] === 0) cleared++;
+  let total = 0;
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+    const a = data[i + 3];
+    if (r === 0 && g === 0 && b === 0 && a === 255) continue;
+    total++;
+    if (a === 0) cleared++;
   }
-  const total = slamCanvas.width * slamCanvas.height;
-  const percent = (cleared / total) * 100;
+  const percent = total ? (cleared / total) * 100 : 0;
   slamCoverageEl.textContent = percent.toFixed(1) + '%';
   const pts = Math.floor(percent);
   if (pts !== coverageScore) {


### PR DESCRIPTION
## Summary
- calculate coverage excluding obstacle cells
- ignore black obstacle pixels when computing slam coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687791c5276c8331bf00646950833ac9