### PR TITLE
Fix overlapping buttons in map/sequence tiles

### DIFF
--- a/VE/templates/index.html
+++ b/VE/templates/index.html
@@ -38,8 +38,14 @@
     }
     .buttons {
       display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
       gap: 5px;
       margin-top: 5px;
+      width: 100%;
+    }
+    .buttons button {
+      flex: 1 0 45%;
     }
     button {
       padding: 5px 10px;

--- a/VE/templates/sequences.html
+++ b/VE/templates/sequences.html
@@ -25,8 +25,14 @@
     }
     .buttons {
       display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
       gap: 5px;
       margin-top: 5px;
+      width: 100%;
+    }
+    .buttons button {
+      flex: 1 0 45%;
     }
     button {
       padding: 5px 10px;


### PR DESCRIPTION
## Summary
- adjust button layout for map tiles
- apply same fix to sequence tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687793e321cc8331a9aabeaaedc2e34d