### PR TITLE
Improve battery mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ API output can be found at `http://127.0.0.1:5000/status`.
 ## Battery model
 
 Each episode starts with a full battery. During simulation the battery level
-decreases proportionally to the car's RPM and the elapsed time. The current
-battery percentage is included in the RL state. If it reaches 0&nbsp;% before the
-goal is achieved the agent receives an additional penalty and the episode ends.
+decreases proportionally to the car's RPM and the elapsed time. The drain rate
+was reduced so the battery lasts roughly four times longer. When the level
+drops to 0&nbsp;% the vehicle can no longer move and the next map is loaded
+automatically. The battery percentage is included in the RL state and if
+depletion happens before the goal is achieved the agent receives an additional
+penalty and the episode ends.
 
 ## Saving and loading maps
 

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -12,7 +12,8 @@ COLLISION_PENALTY = -20
 NEAR_PENALTY = -5
 GOAL_REWARD = 150
 WAYPOINT_REWARD = 15
-BATTERY_RATE = 0.00002        # battery drain per rpm-second
+# Battery drain per rpm-second (reduced for longer runtime)
+BATTERY_RATE = 0.000005
 BATTERY_PENALTY = -50         # punishment when battery depleted before goal
 
 class ServerEnv:

--- a/VE/static/src/car/car.js
+++ b/VE/static/src/car/car.js
@@ -1,4 +1,5 @@
-const BATTERY_RATE = 0.00002;
+// Battery drain per rpm-second (reduced for longer runtime)
+const BATTERY_RATE = 0.000005;
 
 export class Car {
   constructor(
@@ -501,6 +502,15 @@ export class Car {
   }
 
   update(canvasWidth, canvasHeight) {
+    if (this.battery <= 0) {
+      this.velocity = 0;
+      this.acceleration = 0;
+      this.angularVelocity = 0;
+      this.speed = 0;
+      this.rpm = 0;
+      this.draw(canvasWidth, canvasHeight);
+      return;
+    }
     if (this.fixedSpeed != null) {
       this.acceleration = 0;
       this.velocity = this.fixedSpeed / 60;

--- a/VE/static/src/main.js
+++ b/VE/static/src/main.js
@@ -93,6 +93,7 @@ let score = 0;
 let coverageScore = 0;
 let coverageInterval = null;
 let lastCrash = false;
+let batteryDepleted = false;
 
 function updateScoreBoard() {
   if (scoreEl) scoreEl.textContent = score;
@@ -747,6 +748,11 @@ function loop() {
   if (posXEl) posXEl.textContent = Math.round(car.posX);
   if (posYEl) posYEl.textContent = Math.round(car.posY);
 
+  if (car.battery <= 0 && !batteryDepleted) {
+    batteryDepleted = true;
+    nextMap();
+  }
+
   const now = Date.now();
   if (now - lastTelemetry >= TELEMETRY_INTERVAL) {
     const front = Math.round(car.redConeLength);
@@ -836,6 +842,7 @@ function loadMapByIndex(idx) {
       updateSlamCoverage();
     }
     car.reset();
+    batteryDepleted = false;
     coverageScore = 0;
     updateScoreBoard();
   });
@@ -865,6 +872,7 @@ function resetMap() {
     updateSlamCoverage();
   }
   car.reset();
+  batteryDepleted = false;
   coverageScore = 0;
   updateScoreBoard();
 }


### PR DESCRIPTION
## Summary
- slow down battery drain and update docs
- disable car controls when the battery is empty
- automatically switch to the next map on depletion
- reset depletion flag on map changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68779fdec5288331b2412f67294d0a4b