### PR TITLE
Add remote test environment server

### DIFF
--- a/RL/remote_env.py
+++ b/RL/remote_env.py
@@ -1,0 +1,31 @@
+import requests
+
+class RemoteEnv:
+    """Client for the HTTP test environment in ``TE/TE.py``."""
+
+    def __init__(self, base_url="http://127.0.0.1:6000"):
+        self.base_url = base_url.rstrip("/")
+        self.state = None
+        self.done = False
+        self._last_reward = 0.0
+
+    def reset(self):
+        res = requests.post(f"{self.base_url}/reset")
+        data = res.json()
+        self.state = data["state"]
+        self.done = data.get("done", False)
+        self._last_reward = data.get("reward", 0.0)
+        return self.state
+
+    def send_action(self, idx):
+        res = requests.post(f"{self.base_url}/step", json={"action": int(idx)})
+        data = res.json()
+        self.state = data["state"]
+        self.done = data.get("done", False)
+        self._last_reward = data.get("reward", 0.0)
+
+    def get_state(self):
+        return self.state
+
+    def compute_reward(self, _s, _s2):
+        return self._last_reward

--- a/RL/train.py
+++ b/RL/train.py
@@ -6,7 +6,7 @@ from utils import ACTIONS
 
 ENV_CHOICE = input("Select environment - [V]irtual or [T]est: ").strip().lower()
 if ENV_CHOICE == "t":
-    from TE import SimEnv as Env
+    from remote_env import RemoteEnv as Env
     env = Env()
 else:
     from environment import ServerEnv as Env


### PR DESCRIPTION
## Summary
- serve the TE simulation via an HTTP API
- add a remote environment client for RL
- update training script to use the remote interface

## Testing
- `python -m py_compile TE/TE.py RL/remote_env.py RL/train.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877bb39d6f48331b7ce432f072d95b9