### PR TITLE
Add RL training progress interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ following services:
 - `http://127.0.0.1:5000/api/grid` for the current occupancy grid.
 The map editor is available at `http://127.0.0.1:5000/map2`. A simple view of the
 API output can be found at `http://127.0.0.1:5000/status`.
+Training progress of the RL agent can be monitored at
+`http://127.0.0.1:5000/rl-progress`.
 
 ## Battery model
 

--- a/VE/static/src/rl_progress.js
+++ b/VE/static/src/rl_progress.js
@@ -1,0 +1,45 @@
+const ctx = document.getElementById('rlChart').getContext('2d');
+const chart = new Chart(ctx, {
+  type: 'line',
+  data: {
+    labels: [],
+    datasets: [
+      {
+        label: 'Reward',
+        borderColor: 'rgb(75, 192, 192)',
+        fill: false,
+        data: [],
+      },
+      {
+        label: 'Epsilon',
+        borderColor: 'rgb(255, 99, 132)',
+        fill: false,
+        data: [],
+        yAxisID: 'epsilonAxis',
+      },
+    ],
+  },
+  options: {
+    scales: {
+      epsilonAxis: {
+        type: 'linear',
+        position: 'right',
+        min: 0,
+        max: 1,
+      },
+    },
+  },
+});
+
+async function refresh() {
+  const res = await fetch('/api/rl-log');
+  if (!res.ok) return;
+  const data = await res.json();
+  chart.data.labels = data.map((d) => d.episode);
+  chart.data.datasets[0].data = data.map((d) => d.reward);
+  chart.data.datasets[1].data = data.map((d) => d.epsilon);
+  chart.update();
+}
+
+setInterval(refresh, 1000);
+refresh();

--- a/VE/templates/rl_progress.html
+++ b/VE/templates/rl_progress.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>RL Training</title>
+  <style>
+    body {background:#111;color:#eee;font-family:Arial,sans-serif;margin:0;padding:20px;}
+  </style>
+</head>
+<body>
+  <h1>RL Training Fortschritt</h1>
+  <canvas id="rlChart" width="600" height="300" style="background:#222;"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script type="module" src="{{ url_for('static', filename='src/rl_progress.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add RL training page in web server
- implement API endpoint to read rl_log.csv
- provide frontend script showing reward and epsilon over time
- document new interface in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877bd9b31ec833191e8c6c10bba5ab4