### PR TITLE
Add RL training tracking GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,7 @@ possible to edit and extend previously created command sequences.
 Sequences saved as CSV or ROS files can also be loaded. When imported, they are
 converted into simple action lists so they can be further adjusted and saved
 again, e.g. in JSON format for advanced features.
+
+## Reinforcement Learning tracker
+
+Run `python RL/gui.py` to open a simple Tkinter window that plots the accumulated reward per episode based on `RL/rl_log.csv`. The chart refreshes every second so you can monitor training progress live.

--- a/RL/gui.py
+++ b/RL/gui.py
@@ -1,0 +1,44 @@
+import csv
+import tkinter as tk
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+LOG_PATH = "rl_log.csv"
+
+class RLTracker(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("RL Training Tracker")
+        self.fig, self.ax = plt.subplots(figsize=(5, 4))
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=1)
+        self.anim = FuncAnimation(self.fig, self.update_plot, interval=1000)
+
+    def read_log(self):
+        episodes = {}
+        with open(LOG_PATH, newline='') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                ep = int(row["episode"])
+                reward = float(row["reward"])
+                episodes.setdefault(ep, 0.0)
+                episodes[ep] += reward
+        eps = sorted(episodes.items())
+        return [e for e, _ in eps], [r for _, r in eps]
+
+    def update_plot(self, _):
+        try:
+            episodes, rewards = self.read_log()
+        except FileNotFoundError:
+            episodes, rewards = [], []
+        self.ax.clear()
+        self.ax.plot(episodes, rewards, marker='o')
+        self.ax.set_xlabel('Episode')
+        self.ax.set_ylabel('Total reward')
+        self.ax.set_title('Training Progress')
+        self.fig.tight_layout()
+        self.canvas.draw()
+
+if __name__ == "__main__":
+    RLTracker().mainloop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask>=2.0
+
+matplotlib


### PR DESCRIPTION
## Summary
- add Tkinter/Matplotlib RL tracker under `RL/gui.py`
- document tracker in README
- include matplotlib in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877bfd8c7e88331bdf1d484161d1620