### PR TITLE
Enable independent execution of project components

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run the Flask application which serves both the HTML interface and the API
 endpoints:
 
 ```bash
-python server.py
+python VE/server.py
 ```
 
 Then open `http://127.0.0.1:5000/` in your browser. The server exposes the
@@ -99,4 +99,12 @@ again, e.g. in JSON format for advanced features.
 
 ## Reinforcement Learning tracker
 
-Run `python RL/gui.py` to open a simple Tkinter window that plots the accumulated reward per episode based on `RL/rl_log.csv`. The chart refreshes every second so you can monitor training progress live.
+Run `python RL/gui.py` to open a simple Tkinter window that plots the accumulated
+reward per episode based on `RL/rl_log.csv`. The chart refreshes every second so
+you can monitor training progress live. Use `--log` to specify an alternative
+CSV file.
+
+The training loop itself lives in `RL/train.py`. Select the environment via the
+`--env` option (`v` for the virtual Flask server from `VE/server.py` or `t` for
+the headless test environment in `TE/TE.py`) and optionally override the log
+location with `--log`.

--- a/RL/gui.py
+++ b/RL/gui.py
@@ -1,23 +1,26 @@
+import argparse
 import csv
+import os
 import tkinter as tk
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
-LOG_PATH = "rl_log.csv"
+DEFAULT_LOG = os.path.join(os.path.dirname(__file__), "rl_log.csv")
 
 class RLTracker(tk.Tk):
-    def __init__(self):
+    def __init__(self, log_path: str):
         super().__init__()
         self.title("RL Training Tracker")
         self.fig, self.ax = plt.subplots(figsize=(5, 4))
         self.canvas = FigureCanvasTkAgg(self.fig, master=self)
         self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=1)
         self.anim = FuncAnimation(self.fig, self.update_plot, interval=1000)
+        self.log_path = log_path
 
     def read_log(self):
         episodes = {}
-        with open(LOG_PATH, newline='') as f:
+        with open(self.log_path, newline="") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 ep = int(row["episode"])
@@ -40,5 +43,15 @@ class RLTracker(tk.Tk):
         self.fig.tight_layout()
         self.canvas.draw()
 
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Visualise RL training progress")
+    parser.add_argument(
+        "--log", default=DEFAULT_LOG, help="path to the training log CSV"
+    )
+    args = parser.parse_args()
+
+    RLTracker(args.log).mainloop()
+
+
 if __name__ == "__main__":
-    RLTracker().mainloop()
+    main()

--- a/TE/TE.py
+++ b/TE/TE.py
@@ -392,8 +392,14 @@ class SimEnv(Environment):
 
 # === Simple manual test ====================================================
 # === HTTP interface ========================================================
-if __name__ == "__main__":
+def main() -> None:
+    """Run the Flask based test environment."""
     from flask import Flask, request, jsonify
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Test environment server")
+    parser.add_argument("--port", type=int, default=6000, help="port to bind to")
+    args = parser.parse_args()
 
     app = Flask(__name__)
 
@@ -403,14 +409,14 @@ if __name__ == "__main__":
     @app.post("/reset")
     def reset():
         """Reset the simulation and return the initial state."""
-        global PREV_STATE
+        nonlocal PREV_STATE
         PREV_STATE = ENV.reset()
         return jsonify(state=PREV_STATE, reward=0.0, done=ENV.done)
 
     @app.post("/step")
     def step():
         """Apply an action index and advance the simulation."""
-        global PREV_STATE
+        nonlocal PREV_STATE
         idx = int(request.json.get("action", 0))
         print(f"Action received: {ACTIONS[idx]}")
         ENV.send_action(idx)
@@ -424,6 +430,10 @@ if __name__ == "__main__":
         """Return the current state without modifying the environment."""
         return jsonify(state=ENV.get_state(), done=ENV.done)
 
-    print("Test environment server running on http://127.0.0.1:6000")
-    app.run(port=6000)
+    print(f"Test environment server running on http://127.0.0.1:{args.port}")
+    app.run(port=args.port)
+
+
+if __name__ == "__main__":
+    main()
 

--- a/VE/server.py
+++ b/VE/server.py
@@ -445,6 +445,20 @@ def slam_map():
     w = len(current_slam_map[0]) if h else 0
     return jsonify({'gridSize': {'width': w, 'height': h}, 'cells': current_slam_map})
 
-if __name__ == '__main__':
-    app.run(debug=True)
+def main() -> None:
+    """Run the simulation server."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Virtual environment server")
+    parser.add_argument(
+        "--port", type=int, default=5000, help="port to bind the web server"
+    )
+    parser.add_argument("--debug", action="store_true", help="enable debug mode")
+    args = parser.parse_args()
+
+    app.run(debug=args.debug, port=args.port)
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- add CLI options for RL training script
- make RL GUI accept path to log file
- expose command line interfaces for the TE and VE servers
- update documentation with new usage examples

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877c1a877c08331846ec98e8d6924ec