### PR TITLE
Enable dynamic RL progress updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ following services:
 The map editor is available at `http://127.0.0.1:5000/map2`. A simple view of the
 API output can be found at `http://127.0.0.1:5000/status`.
 Training progress of the RL agent can be monitored at
-`http://127.0.0.1:5000/rl-progress`.
+`http://127.0.0.1:5000/rl-progress`. The chart on this page now refreshes
+automatically so you can watch rewards and epsilon values update during
+training.
 
 ## Battery model
 

--- a/RL/GUI.py
+++ b/RL/GUI.py
@@ -38,6 +38,7 @@ HTML = """
     <tbody></tbody>
   </table>
 <script>
+let chart;
 async function loadData() {
   const res = await fetch('/api/log');
   const data = await res.json();
@@ -55,20 +56,28 @@ async function loadData() {
                    `<td>${row.epsilon.toFixed(3)}</td>`;
     tbody.appendChild(tr);
   }
-  const ctx = document.getElementById('chart').getContext('2d');
   const labels = data.episodes.map(e => e.episode);
   const rewards = data.episodes.map(e => e.reward);
   const eps = data.episodes.map(e => e.epsilon);
-  new Chart(ctx, {
-    type:'line',
-    data:{labels:labels,datasets:[
-      {label:'Reward',borderColor:'rgb(75,192,192)',data:rewards,fill:false},
-      {label:'Epsilon',borderColor:'rgb(255,99,132)',data:eps,fill:false,yAxisID:'eps'}
-    ]},
-    options:{scales:{eps:{type:'linear',position:'right',min:0,max:1}}}
-  });
+  if (!chart) {
+    const ctx = document.getElementById('chart').getContext('2d');
+    chart = new Chart(ctx, {
+      type:'line',
+      data:{labels:labels,datasets:[
+        {label:'Reward',borderColor:'rgb(75,192,192)',data:rewards,fill:false},
+        {label:'Epsilon',borderColor:'rgb(255,99,132)',data:eps,fill:false,yAxisID:'eps'}
+      ]},
+      options:{scales:{eps:{type:'linear',position:'right',min:0,max:1}}}
+    });
+  } else {
+    chart.data.labels = labels;
+    chart.data.datasets[0].data = rewards;
+    chart.data.datasets[1].data = eps;
+    chart.update();
+  }
 }
 loadData();
+setInterval(loadData, 5000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make RL GUI auto-refresh every few seconds so training progress is shown live
- mention automatic refresh of RL progress chart in README

## Testing
- `python -m py_compile RL/GUI.py RL/train.py RL/environment.py RL/remote_env.py RL/logger.py RL/agent.py RL/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6877cd2ffd68833191778398d4e0f2f2