### PR TITLE
Flush RL logs after every episode

### DIFF
--- a/RL/logger.py
+++ b/RL/logger.py
@@ -10,5 +10,9 @@ class Logger:
     def log(self, ep, st, act, state, rew, done, eps):
         self.writer.writerow([ep, st, datetime.now().isoformat(), act, state, rew, done, round(eps, 5)])
 
+    def flush(self):
+        """Ensure that all logged data is written to disk."""
+        self.file.flush()
+
     def close(self):
         self.file.close()

--- a/RL/train.py
+++ b/RL/train.py
@@ -31,4 +31,5 @@ if __name__ == '__main__':
             if done:
                 break
         agent.replay()
+        logger.flush()
     logger.close()


### PR DESCRIPTION
## Summary
- ensure that the logger exposes a `flush` method
- flush the log file after each training episode

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877ce9dca608331965c57457d4f778a