### PR TITLE
Add model persistence for DQN agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Training progress of the RL agent can be monitored at
 automatically so you can watch rewards and epsilon values update during
 training.
 
+### Saving the RL model
+
+The training script automatically stores the neural network under
+`RL/dqn_model.keras` after each episode. When you run `train.py` again, it will
+load this file if present so training can continue from the previous state.
+
 ## Battery model
 
 Each episode starts with a full battery. During simulation the battery level

--- a/RL/train.py
+++ b/RL/train.py
@@ -13,8 +13,10 @@ else:
     from environment import ServerEnv as Env
     env = Env(BASE_URL)
 
+MODEL_FILE = Path(__file__).with_name("dqn_model.keras")
+
 if __name__ == '__main__':
-    agent = DQNAgent()
+    agent = DQNAgent(str(MODEL_FILE) if MODEL_FILE.exists() else None)
     log_path = Path(__file__).with_name("rl_log.csv")
     logger = Logger(str(log_path))
     for ep in range(NUM_EPISODES):
@@ -34,5 +36,6 @@ if __name__ == '__main__':
                 break
         agent.replay()
         logger.flush()
+        agent.save(str(MODEL_FILE))
         print(f"Episode {ep} finished after {st + 1} steps with reward {total:.2f}")
     logger.close()


### PR DESCRIPTION
## Summary
- allow the RL agent to load and save a model
- automatically store model after every episode
- document model saving in README

## Testing
- `npm test --prefix VE`

------
https://chatgpt.com/codex/tasks/task_e_6877d378b5288331a84a47bf20576c83