### PR TITLE
Add dual training environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Training progress of the RL agent can be monitored at
 automatically so you can watch rewards and epsilon values update during
 training.
 
+To start training run `python RL/train.py`. The script asks which
+environment to use:
+
+- `[V]`irtual – train directly against the browser based simulator.
+- `[T]`est – use the headless environment from `TE/TE.py`.
+- `[B]`oth – train in the test environment while mirroring the actions to
+  the virtual simulator for visualisation.
+
 ### Saving the RL model
 
 The training script automatically stores the neural network under

--- a/RL/dual_env.py
+++ b/RL/dual_env.py
@@ -1,0 +1,44 @@
+"""Environment wrapper that mirrors actions to the server visualization.
+
+This class combines the headless training environment accessed via
+:class:`RemoteEnv` with the interactive server based environment
+(:class:`ServerEnv`). All state and reward calculations come from the
+training environment while the same actions are forwarded to the server
+for visualisation.
+"""
+
+from remote_env import RemoteEnv
+from environment import ServerEnv
+from config import BASE_URL
+
+
+class DualEnv:
+    """Run actions on both the training and server environments."""
+
+    def __init__(self, train_url: str = "http://127.0.0.1:6000", base_url: str = BASE_URL):
+        self.train_env = RemoteEnv(train_url)
+        self.display_env = ServerEnv(base_url)
+        self.done = False
+
+    def reset(self):
+        state = self.train_env.reset()
+        try:
+            self.display_env.reset()
+        except Exception:
+            pass
+        self.done = self.train_env.done
+        return state
+
+    def send_action(self, idx):
+        try:
+            self.display_env.send_action(idx)
+        except Exception:
+            pass
+        self.train_env.send_action(idx)
+        self.done = self.train_env.done
+
+    def get_state(self):
+        return self.train_env.get_state()
+
+    def compute_reward(self, s, s2):
+        return self.train_env.compute_reward(s, s2)

--- a/RL/train.py
+++ b/RL/train.py
@@ -5,9 +5,14 @@ from logger import Logger
 from pathlib import Path
 from utils import ACTIONS
 
-ENV_CHOICE = input("Select environment - [V]irtual or [T]est: ").strip().lower()
+ENV_CHOICE = input(
+    "Select environment - [V]irtual, [T]est or [B]oth: "
+).strip().lower()
 if ENV_CHOICE == "t":
     from remote_env import RemoteEnv as Env
+    env = Env()
+elif ENV_CHOICE == "b":
+    from dual_env import DualEnv as Env
     env = Env()
 else:
     from environment import ServerEnv as Env


### PR DESCRIPTION
## Summary
- add a `DualEnv` that proxies actions to the virtual server while training against the headless environment
- allow selecting the new `[B]oth` option in `train.py`
- document training options in the README

## Testing
- `python -m py_compile RL/dual_env.py RL/train.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877dcd166888331b3cfd8d7786d5dec