### PR TITLE
Add fine-grained camera control actions

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -123,12 +123,16 @@ class ServerEnv:
         self.waypoint_hit = False
         action = ACTIONS[idx]
         payload = {"action": action}
-        if action == "cam_left":
-            payload = {"action": "camera2", "value": -45}
-        elif action == "cam_center":
-            payload = {"action": "camera2", "value": 0}
-        elif action == "cam_right":
-            payload = {"action": "camera2", "value": 45}
+
+        # Camera commands are encoded as "cam_<angle>" where <angle> is an
+        # integer between -90 and 90 degrees.  Forward them to the server using
+        # the ``camera2`` control action.
+        if action.startswith("cam_"):
+            try:
+                angle = int(action.split("_", 1)[1])
+            except (IndexError, ValueError):
+                angle = 0
+            payload = {"action": "camera2", "value": angle}
         try:
             requests.post(f"{self.base_url}/api/control", json=payload, timeout=5)
         except Exception:

--- a/RL/utils.py
+++ b/RL/utils.py
@@ -1,15 +1,24 @@
-# Available actions for the RL agent. Besides the basic driving commands
-# three additional entries allow controlling the second camera. The camera
-# can be pointed 45 degrees to the left or right or straight ahead.
+"""Definition of all available actions for the RL agent.
+
+The first five entries are the basic driving commands. Following those we
+generate camera actions that allow pointing the second camera at any angle
+between -90 and 90 degrees (inclusive).  The individual actions are encoded as
+``cam_<angle>`` where ``<angle>`` is an integer value.  This gives the agent a
+discrete choice of 181 different camera positions which covers the full
+rotation range in one degree steps.
+"""
+
+# Basic driving actions
 ACTIONS = [
     "forward",
     "left",
     "right",
     "backward",
     "stop",
-    "cam_left",
-    "cam_center",
-    "cam_right",
 ]
+
+# Generate camera actions from -90 to 90 degrees
+ACTIONS += [f"cam_{deg}" for deg in range(-90, 91)]
+
 STATE_SIZE = 8
 ACTION_SIZE = len(ACTIONS)

--- a/TE/TE.py
+++ b/TE/TE.py
@@ -247,7 +247,12 @@ class Car:
         dt = now - self.last_update
         self.last_update = now
 
-        if action in ("cam_left", "cam_center", "cam_right"):
+        # Ignore any camera control commands in the headless environment.  The
+        # simulator does not model a second camera, so these actions merely
+        # repeat the previously executed driving command.  Camera actions are
+        # encoded as ``cam_<angle>`` where ``<angle>`` is the desired camera
+        # rotation in degrees.
+        if action.startswith("cam_"):
             action = self._last_drive
         else:
             self._last_drive = action
@@ -322,16 +327,19 @@ class Car:
 
 
 # === Environment ===========================================================
+"""Action names used by the headless simulation environment."""
 ACTIONS = [
     "forward",
     "left",
     "right",
     "backward",
     "stop",
-    "cam_left",
-    "cam_center",
-    "cam_right",
 ]
+
+# Add camera actions for angles between -90 and 90 degrees.  The car model
+# itself ignores these actions but they are included to mirror the action space
+# of the RL environment.
+ACTIONS += [f"cam_{deg}" for deg in range(-90, 91)]
 
 
 class SimEnv(Environment):


### PR DESCRIPTION
## Summary
- expand the RL action space with `cam_<angle>` actions for angles -90..90
- interpret new camera actions in the environment and mirror them to the server
- ignore generic camera actions in the headless test environment

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877de9442608331af5168de7def0c60