### PR TITLE
Enable simultaneous drive and camera commands

### DIFF
--- a/RL/train.py
+++ b/RL/train.py
@@ -3,7 +3,7 @@ from config import BASE_URL, NUM_EPISODES, MAX_STEPS
 from agent import DQNAgent
 from logger import Logger
 from pathlib import Path
-from utils import ACTIONS
+from utils import ACTIONS, format_action
 
 ENV_CHOICE = input(
     "Select environment - [V]irtual, [T]est or [B]oth: "
@@ -34,7 +34,7 @@ if __name__ == '__main__':
             r = env.compute_reward(state, s2)
             done = env.done
             agent.remember(state, a, r, s2, done)
-            logger.log(ep, st, ACTIONS[a], state, r, done, agent.epsilon)
+            logger.log(ep, st, format_action(ACTIONS[a]), state, r, done, agent.epsilon)
             state = s2
             total += r
             if done:

--- a/RL/utils.py
+++ b/RL/utils.py
@@ -1,15 +1,13 @@
 """Definition of all available actions for the RL agent.
 
-The first five entries are the basic driving commands. Following those we
-generate camera actions that allow pointing the second camera at any angle
-between -90 and 90 degrees (inclusive).  The individual actions are encoded as
-``cam_<angle>`` where ``<angle>`` is an integer value.  This gives the agent a
-discrete choice of 181 different camera positions which covers the full
-rotation range in one degree steps.
+Actions consist of a combination of a driving command and a camera angle. This
+allows the agent to move the car while adjusting the viewing direction within a
+single step.  The driving component supports the basic motion commands while
+the camera angle can be set anywhere between -90 and 90 degrees (inclusive).
 """
 
-# Basic driving actions
-ACTIONS = [
+# Basic driving commands
+DRIVE_ACTIONS = [
     "forward",
     "left",
     "right",
@@ -17,8 +15,20 @@ ACTIONS = [
     "stop",
 ]
 
-# Generate camera actions from -90 to 90 degrees
-ACTIONS += [f"cam_{deg}" for deg in range(-90, 91)]
+# Camera angles from -90 to 90 degrees in one degree steps
+CAMERA_ANGLES = list(range(-90, 91))
+
+# Create the full action space as the Cartesian product of driving commands and
+# camera orientations.  Each entry is a tuple ``(drive_cmd, angle)``.
+ACTIONS = [
+    (d, a) for d in DRIVE_ACTIONS for a in CAMERA_ANGLES
+]
 
 STATE_SIZE = 8
 ACTION_SIZE = len(ACTIONS)
+
+
+def format_action(action):
+    """Return a readable representation of an action tuple."""
+    drive, angle = action
+    return f"{drive}|cam_{angle}"

--- a/TE/TE.py
+++ b/TE/TE.py
@@ -328,7 +328,9 @@ class Car:
 
 # === Environment ===========================================================
 """Action names used by the headless simulation environment."""
-ACTIONS = [
+
+# Basic driving commands
+DRIVE_ACTIONS = [
     "forward",
     "left",
     "right",
@@ -336,10 +338,15 @@ ACTIONS = [
     "stop",
 ]
 
-# Add camera actions for angles between -90 and 90 degrees.  The car model
-# itself ignores these actions but they are included to mirror the action space
-# of the RL environment.
-ACTIONS += [f"cam_{deg}" for deg in range(-90, 91)]
+# Camera angles
+CAMERA_ANGLES = list(range(-90, 91))
+
+# Cartesian product of driving and camera commands.  Camera angles are ignored
+# by the simulator but included so the action space mirrors that of the RL
+# environment.
+ACTIONS = [
+    (d, a) for d in DRIVE_ACTIONS for a in CAMERA_ANGLES
+]
 
 
 class SimEnv(Environment):
@@ -360,8 +367,10 @@ class SimEnv(Environment):
 
     # ------------------------------------------------------------------
     def send_action(self, action_index: int) -> None:
-        action = ACTIONS[action_index]
-        self.car.update(action)
+        drive, _angle = ACTIONS[action_index]
+        # The simulator does not model the second camera, so only the driving
+        # command influences the state.  The camera angle component is ignored.
+        self.car.update(drive)
         self._check_goal()
         if self.car.battery <= 0:
             self.done = True


### PR DESCRIPTION
## Summary
- expand action space to (drive, camera) pairs
- send driving and camera commands together
- adjust test simulator to accept new action format
- log readable action strings during training

## Testing
- `python -m py_compile RL/*.py TE/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6877e241e7dc8331b345fbf9e9495c31