### PR TITLE
Display map name after each RL episode

### DIFF
--- a/RL/dual_env.py
+++ b/RL/dual_env.py
@@ -19,6 +19,7 @@ class DualEnv:
         self.train_env = RemoteEnv(train_url)
         self.display_env = ServerEnv(base_url)
         self.done = False
+        self.map_name = "unknown"
 
     def reset(self):
         state = self.train_env.reset()
@@ -42,3 +43,11 @@ class DualEnv:
 
     def compute_reward(self, s, s2):
         return self.train_env.compute_reward(s, s2)
+
+    def get_map_name(self):
+        """Return the name of the current map if available."""
+        try:
+            self.map_name = self.display_env.get_map_name()
+        except Exception:
+            pass
+        return self.map_name

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -27,6 +27,7 @@ class ServerEnv:
         self.last_move_time = time.time()
         self.battery = 1.0
         self.last_state_time = time.time()
+        self.map_name = "unknown"
 
     def reset(self):
         """Restart the simulator and return the initial state."""
@@ -38,6 +39,8 @@ class ServerEnv:
         self.last_move_time = time.time()
         self.battery = 1.0
         self.last_state_time = time.time()
+        # Update the current map name before restarting
+        self._update_map_name()
         try:
             # Trigger a restart of the simulator which resets the car to the
             # starting position. The front-end listens for this control command
@@ -117,6 +120,20 @@ class ServerEnv:
         if coverage >= 0.95:
             self.done = True
         return [front, left, right, speed, gyro, rpm, coverage, self.battery]
+
+    def _update_map_name(self):
+        """Retrieve the name of the currently loaded map from the server."""
+        try:
+            res = requests.get(f"{self.base_url}/api/maps", timeout=5)
+            maps = res.json()
+            if maps:
+                self.map_name = maps[-1].get("name", self.map_name)
+        except Exception:
+            pass
+
+    def get_map_name(self):
+        """Return the most recently reported map name."""
+        return self.map_name
 
     def send_action(self, idx):
         """Send a driving and camera command for the chosen action index."""

--- a/RL/remote_env.py
+++ b/RL/remote_env.py
@@ -8,6 +8,7 @@ class RemoteEnv:
         self.state = None
         self.done = False
         self._last_reward = 0.0
+        self.map_name = "test"
 
     def reset(self):
         res = requests.post(f"{self.base_url}/reset")
@@ -29,3 +30,6 @@ class RemoteEnv:
 
     def compute_reward(self, _s, _s2):
         return self._last_reward
+
+    def get_map_name(self):
+        return self.map_name

--- a/RL/train.py
+++ b/RL/train.py
@@ -42,5 +42,8 @@ if __name__ == '__main__':
         agent.replay()
         logger.flush()
         agent.save(str(MODEL_FILE))
-        print(f"Episode {ep} finished after {st + 1} steps with reward {total:.2f}")
+        map_name = getattr(env, "get_map_name", lambda: "unknown")()
+        print(
+            f"Episode {ep} finished after {st + 1} steps with reward {total:.2f} on map {map_name}"
+        )
     logger.close()


### PR DESCRIPTION
## Summary
- add tracking of the current map name in `ServerEnv`
- expose `get_map_name` helper in environment classes
- print the active map in `train.py`

## Testing
- `python -m py_compile RL/environment.py RL/dual_env.py RL/remote_env.py RL/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6877e73db7e88331893db03b4f53dffb