### PR TITLE
Add termination flags to environment

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -24,6 +24,8 @@ class ServerEnv:
         self.map_switched = False
         self.waypoint_hit = False
         self.stalled = False
+        self.crashed = False
+        self.coverage_done = False
         self.last_move_time = time.time()
         self.battery = 1.0
         self.last_state_time = time.time()
@@ -36,6 +38,8 @@ class ServerEnv:
         self.map_switched = False
         self.waypoint_hit = False
         self.stalled = False
+        self.crashed = False
+        self.coverage_done = False
         self.last_move_time = time.time()
         self.battery = 1.0
         self.last_state_time = time.time()
@@ -116,8 +120,10 @@ class ServerEnv:
         # occurred. As we do not get explicit signals from the simulator we use
         # simple heuristics based on the sensor values.
         if front <= 1:
+            self.crashed = True
             self.done = True
         if coverage >= 0.95:
+            self.coverage_done = True
             self.done = True
         return [front, left, right, speed, gyro, rpm, coverage, self.battery]
 

--- a/RL/train.py
+++ b/RL/train.py
@@ -33,6 +33,8 @@ if __name__ == '__main__':
             env.send_action(a)
             s2 = env.get_state()
             map_switched = getattr(env, "map_switched", False)
+            crashed = getattr(env, "crashed", False)
+            coverage_done = getattr(env, "coverage_done", False)
             battery = getattr(env, "battery", 1.0)
             r = env.compute_reward(state, s2)
             done = env.done
@@ -45,6 +47,10 @@ if __name__ == '__main__':
                     termination_reason = "Batterie leer"
                 elif map_switched:
                     termination_reason = "Ziel erreicht"
+                elif crashed:
+                    termination_reason = "Crash"
+                elif coverage_done:
+                    termination_reason = "95% Abdeckung"
                 else:
                     termination_reason = "Beendet"
                 break


### PR DESCRIPTION
## Summary
- track crash and coverage states in ServerEnv
- report new termination reasons in training

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877ee8b50488331a9c7fda7e94c448d