### PR TITLE
Expose telemetry fields in test API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ environment to use:
 - `[B]`oth – train in the test environment while mirroring the actions to
   the virtual simulator for visualisation.
 
+### Test environment API
+
+The test environment exposes `/reset` and `/step` endpoints. Both return
+JSON data with the following structure:
+
+```json
+{
+  "state": [...],
+  "reward": 0.0,
+  "done": false,
+  "goal_reached": false,
+  "crashed": false,
+  "battery": 1.0
+}
+```
+
+`goal_reached` mirrors the `map_switched` flag of the normal simulator and
+indicates that the target was reached. `battery` provides the remaining
+energy level from 0.0 to 1.0.
+
 ### Saving the RL model
 
 The training script automatically stores the neural network under

--- a/RL/remote_env.py
+++ b/RL/remote_env.py
@@ -9,6 +9,9 @@ class RemoteEnv:
         self.done = False
         self._last_reward = 0.0
         self.map_name = "test"
+        self.map_switched = False
+        self.crashed = False
+        self.battery = 1.0
 
     def reset(self):
         res = requests.post(f"{self.base_url}/reset")
@@ -16,6 +19,9 @@ class RemoteEnv:
         self.state = data["state"]
         self.done = data.get("done", False)
         self._last_reward = data.get("reward", 0.0)
+        self.map_switched = data.get("goal_reached", False)
+        self.crashed = data.get("crashed", False)
+        self.battery = data.get("battery", 1.0)
         return self.state
 
     def send_action(self, idx):
@@ -24,6 +30,9 @@ class RemoteEnv:
         self.state = data["state"]
         self.done = data.get("done", False)
         self._last_reward = data.get("reward", 0.0)
+        self.map_switched = data.get("goal_reached", False)
+        self.crashed = data.get("crashed", False)
+        self.battery = data.get("battery", self.battery)
 
     def get_state(self):
         return self.state

--- a/RL/train.py
+++ b/RL/train.py
@@ -34,7 +34,8 @@ if __name__ == '__main__':
             s2 = env.get_state()
             # Capture termination flags before they might be reset by
             # ``compute_reward`` so the reason can be reported accurately.
-            map_switched = getattr(env, "map_switched", False)
+            # Values may be provided by the RemoteEnv HTTP API
+            map_switched = getattr(env, "map_switched", getattr(env, "goal_reached", False))
             crashed = getattr(env, "crashed", False)
             coverage_done = getattr(env, "coverage_done", False)
             stalled = getattr(env, "stalled", False)

--- a/TE/TE.py
+++ b/TE/TE.py
@@ -422,7 +422,14 @@ if __name__ == "__main__":
         """Reset the simulation and return the initial state."""
         global PREV_STATE
         PREV_STATE = ENV.reset()
-        return jsonify(state=PREV_STATE, reward=0.0, done=ENV.done)
+        return jsonify(
+            state=PREV_STATE,
+            reward=0.0,
+            done=ENV.done,
+            goal_reached=ENV.goal_reached,
+            crashed=ENV.car.crashed,
+            battery=ENV.car.battery,
+        )
 
     @app.post("/step")
     def step():
@@ -434,7 +441,14 @@ if __name__ == "__main__":
         new_state = ENV.get_state()
         reward = ENV.compute_reward(PREV_STATE, new_state)
         PREV_STATE = new_state
-        return jsonify(state=new_state, reward=reward, done=ENV.done)
+        return jsonify(
+            state=new_state,
+            reward=reward,
+            done=ENV.done,
+            goal_reached=ENV.goal_reached,
+            crashed=ENV.car.crashed,
+            battery=ENV.car.battery,
+        )
 
     @app.get("/state")
     def state():


### PR DESCRIPTION
## Summary
- extend `/reset` and `/step` in `TE.py` to include `goal_reached`, `crashed` and `battery`
- capture these values inside `RemoteEnv`
- read `goal_reached` flag when training
- document the JSON structure of the test environment responses

## Testing
- `python -m py_compile TE/TE.py RL/remote_env.py RL/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6877f249315483319a6eb9763024893c