### PR TITLE
Add detailed termination reasons to test env

### DIFF
--- a/RL/dual_env.py
+++ b/RL/dual_env.py
@@ -28,6 +28,11 @@ class DualEnv:
         except Exception:
             pass
         self.done = self.train_env.done
+        self.map_switched = getattr(self.train_env, "map_switched", False)
+        self.crashed = getattr(self.train_env, "crashed", False)
+        self.coverage_done = getattr(self.train_env, "coverage_done", False)
+        self.stalled = getattr(self.train_env, "stalled", False)
+        self.battery = getattr(self.train_env, "battery", 1.0)
         return state
 
     def send_action(self, idx):
@@ -37,6 +42,11 @@ class DualEnv:
             pass
         self.train_env.send_action(idx)
         self.done = self.train_env.done
+        self.map_switched = getattr(self.train_env, "map_switched", False)
+        self.crashed = getattr(self.train_env, "crashed", False)
+        self.coverage_done = getattr(self.train_env, "coverage_done", False)
+        self.stalled = getattr(self.train_env, "stalled", False)
+        self.battery = getattr(self.train_env, "battery", 1.0)
 
     def get_state(self):
         return self.train_env.get_state()

--- a/RL/remote_env.py
+++ b/RL/remote_env.py
@@ -12,6 +12,9 @@ class RemoteEnv:
         self.map_switched = False
         self.crashed = False
         self.battery = 1.0
+        self.coverage_done = False
+        self.stalled = False
+        self.coverage = 0.0
 
     def reset(self):
         res = requests.post(f"{self.base_url}/reset")
@@ -22,6 +25,9 @@ class RemoteEnv:
         self.map_switched = data.get("goal_reached", False)
         self.crashed = data.get("crashed", False)
         self.battery = data.get("battery", 1.0)
+        self.coverage = data.get("coverage", 0.0)
+        self.coverage_done = data.get("coverage_done", False)
+        self.stalled = data.get("stalled", False)
         return self.state
 
     def send_action(self, idx):
@@ -33,6 +39,9 @@ class RemoteEnv:
         self.map_switched = data.get("goal_reached", False)
         self.crashed = data.get("crashed", False)
         self.battery = data.get("battery", self.battery)
+        self.coverage = data.get("coverage", self.coverage)
+        self.coverage_done = data.get("coverage_done", False)
+        self.stalled = data.get("stalled", False)
 
     def get_state(self):
         return self.state


### PR DESCRIPTION
## Summary
- add stall and coverage tracking to `SimEnv`
- expose additional termination flags from test server
- sync flags through `RemoteEnv` and `DualEnv`

## Testing
- `python -m py_compile TE/TE.py RL/remote_env.py RL/dual_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6877f6bcc3b48331abc820a7526ed9e2