### PR TITLE
Fix map name retrieval for RL episodes

### DIFF
--- a/RL/dual_env.py
+++ b/RL/dual_env.py
@@ -57,7 +57,8 @@ class DualEnv:
     def get_map_name(self):
         """Return the name of the current map if available."""
         try:
-            self.map_name = self.display_env.get_map_name()
+            if getattr(self, "map_switched", False) or self.map_name == "unknown":
+                self.map_name = self.display_env.get_map_name()
         except Exception:
             pass
         return self.map_name

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -139,6 +139,8 @@ class ServerEnv:
 
     def get_map_name(self):
         """Return the most recently reported map name."""
+        if self.map_switched or self.map_name == "unknown":
+            self._update_map_name()
         return self.map_name
 
     def send_action(self, idx):


### PR DESCRIPTION
## Summary
- update map name retrieval in `ServerEnv.get_map_name`
- update `DualEnv.get_map_name` so changed maps show correctly

## Testing
- `python -m py_compile RL/*.py VE/server.py TE/TE.py || true`

------
https://chatgpt.com/codex/tasks/task_e_6877f9c8a9108331a30610aab771e8bd