### PR TITLE
Fix coverage check for virtual environment

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -99,8 +99,14 @@ class ServerEnv:
             cells = slam_res.json().get("cells", [])
             non_obstacle = [val for row in cells for val in row if val != 2]
             total = len(non_obstacle)
-            known = sum(1 for val in non_obstacle if val != 0)
-            coverage = known / total if total else 0.0
+            if total and all(val != 0 for val in non_obstacle):
+                # The virtual environment returns the static grid when no
+                # SLAM map is available. Treat this case as 0% coverage so the
+                # agent does not immediately terminate an episode.
+                coverage = 0.0
+            else:
+                known = sum(1 for val in non_obstacle if val != 0)
+                coverage = known / total if total else 0.0
         except Exception:
             coverage = 0.0
         try:


### PR DESCRIPTION
## Summary
- adjust coverage calculation in RL environment to detect when the virtual
  environment only returns the static grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877fbafdc3c833180183b9d492ddb5e