### PR TITLE
Enable map switching and reporting

### DIFF
--- a/RL/remote_env.py
+++ b/RL/remote_env.py
@@ -1,14 +1,17 @@
+import os
 import requests
 
 class RemoteEnv:
     """Client for the HTTP test environment in ``TE/TE.py``."""
 
-    def __init__(self, base_url="http://127.0.0.1:6000"):
+    def __init__(self, base_url="http://127.0.0.1:6000", maps=None):
         self.base_url = base_url.rstrip("/")
         self.state = None
         self.done = False
         self._last_reward = 0.0
-        self.map_name = "test"
+        self.maps = maps or ["Level1.csv", "Level2.csv", "Level3.csv", "Level4.csv"]
+        self.map_index = 0
+        self.map_name = os.path.splitext(os.path.basename(self.maps[self.map_index]))[0]
         self.map_switched = False
         self.crashed = False
         self.battery = 1.0
@@ -17,6 +20,17 @@ class RemoteEnv:
         self.coverage = 0.0
 
     def reset(self):
+        if (self.map_switched or self.coverage_done) and self.maps:
+            self.map_index = (self.map_index + 1) % len(self.maps)
+            try:
+                requests.post(
+                    f"{self.base_url}/load_map",
+                    json={"file": self.maps[self.map_index]},
+                    timeout=5,
+                )
+            except Exception:
+                pass
+            self.map_name = os.path.splitext(os.path.basename(self.maps[self.map_index]))[0]
         res = requests.post(f"{self.base_url}/reset")
         data = res.json()
         self.state = data["state"]
@@ -28,6 +42,7 @@ class RemoteEnv:
         self.coverage = data.get("coverage", 0.0)
         self.coverage_done = data.get("coverage_done", False)
         self.stalled = data.get("stalled", False)
+        self.map_name = data.get("map_name", self.map_name)
         return self.state
 
     def send_action(self, idx):
@@ -42,6 +57,7 @@ class RemoteEnv:
         self.coverage = data.get("coverage", self.coverage)
         self.coverage_done = data.get("coverage_done", False)
         self.stalled = data.get("stalled", False)
+        self.map_name = data.get("map_name", self.map_name)
 
     def get_state(self):
         return self.state


### PR DESCRIPTION
## Summary
- allow loading maps in TE/TE.py via `/load_map`
- include `map_name` in `/reset` and `/step` responses
- add map rotation and map name handling in RL remote environment

## Testing
- `python -m py_compile TE/TE.py RL/remote_env.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fb3c80688331944e36cf0ea39c89