### PR TITLE
Restart map when episode ends early

### DIFF
--- a/RL/train.py
+++ b/RL/train.py
@@ -60,6 +60,14 @@ if __name__ == '__main__':
                 else:
                     termination_reason = "Unbekannt"
                 break
+        # Restart the map after early termination so the next episode begins
+        # with a clean SLAM map and full battery.  Only keep the current map
+        # when coverage finished the episode.
+        if termination_reason != "95% Abdeckung":
+            try:
+                env.reset()
+            except Exception:
+                pass
         agent.replay()
         logger.flush()
         agent.save(str(MODEL_FILE))


### PR DESCRIPTION
## Summary
- ensure the map restarts after an episode ends for any reason other than 95 % coverage

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877ff20346483319d6c2f36c2625ab5