### PR TITLE
Fix map name retrieval in DualEnv

### DIFF
--- a/RL/dual_env.py
+++ b/RL/dual_env.py
@@ -58,7 +58,7 @@ class DualEnv:
         """Return the name of the current map if available."""
         try:
             if getattr(self, "map_switched", False) or self.map_name == "unknown":
-                self.map_name = self.display_env.get_map_name()
+                self.map_name = self.train_env.get_map_name()
         except Exception:
             pass
         return self.map_name


### PR DESCRIPTION
## Summary
- fix DualEnv.get_map_name to query the training environment instead of the display environment

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877ff389a688331913def0fe492b500